### PR TITLE
chore: More dry monad, more tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,19 +13,31 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "jest",
-    "prepublish": "yarn test && yarn build"
+    "test": "jest"
   },
   "author": "Justin Miller",
   "license": "MIT",
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
   "devDependencies": {
     "@types/jest": "^23.3.1",
     "fast-check": "^1.5.0",
+    "husky": "^1.1.4",
     "jest": "^23.5.0",
     "jest-junit": "^5.1.0",
+    "lint-staged": "^8.0.5",
     "prettier": "^1.14.3",
     "ts-jest": "^23.1.4",
     "typescript": "^3.0.3"
+  },
+  "lint-staged": {
+    "*.{js,json,css,md}": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "jest": {
     "transform": {

--- a/src/either.spec.ts
+++ b/src/either.spec.ts
@@ -1,49 +1,60 @@
-import { Either, Left, Right } from "./either";
+import { Either } from "./either";
 
+const value = {
+  left: (x: any): any => x,
+  right: (x: any): any => x
+};
 describe("either", () => {
   describe("left(4)", () => {
-    const given = Left.of(4);
+    const given = Either.left(4);
+    it("should equal string left(4)", () => {
+      expect(`${given}`).toEqual("left(4)");
+    });
     it("should be able to default to a value", () => {
       const answer = { hi: "there" };
       expect(given.defaultTo(answer)).toBe(answer);
     });
     it("map over function 2x", () => {
-      expect(given.map(x => 2 * x).value).toBe(4);
+      expect(given.map(x => 2 * x).fold(value)).toBe(4);
     });
     it("chain over function right 2x", () => {
-      expect(given.chain(x => Right.of(2 * x)).value).toBe(4);
+      expect(given.chain(x => Either.right(2 * x)).fold(value)).toBe(4);
     });
     it("chain over function left 3x", () => {
-      expect(given.chain(x => Left.of(3 * x)).value).toBe(4);
+      expect(given.chain(x => Either.left(3 * x)).fold(value)).toBe(4);
     });
     it("chain left over function left 4x", () => {
-      expect(given.chainLeft(x => Left.of(4 * x)).value).toBe(16);
+      expect(given.chain(x => Either.left(4 * x), "left").fold(value)).toBe(16);
     });
     it("chain left over function right 4x", () => {
-      expect(given.chainLeft(x => Right.of(4 * x)).value).toBe(16);
+      expect(given.chain(x => Either.right(4 * x), "left").fold(value)).toBe(
+        16
+      );
     });
-
   });
   describe("right(5)", () => {
-    const given = Right.of(5);
+    const given = Either.right(5);
+    it("should equal string right(5)", () => {
+      expect(`${given}`).toEqual("right(5)");
+    });
     it("should be able to default to a value", () => {
       const defaultValue = 6;
       expect(given.defaultTo(defaultValue)).toBe(5);
     });
     it("map will work over function  2x", () => {
-      expect(given.map(x => 2 * x).value).toBe(10);
+      expect(given.map(x => 2 * x).fold(value)).toBe(10);
     });
     it("chain over function right 3x", () => {
-      expect(given.chain(x => Right.of(3 * x)).value).toBe(15);
+      expect(given.chain(x => Either.right(3 * x)).fold(value)).toBe(15);
     });
     it("chain over function left 3x", () => {
-      expect(given.chain(x => Left.of(3 * x)).value).toBe(15);
+      expect(given.chain(x => Either.left(3 * x)).fold(value)).toBe(15);
     });
     it("chain left over function left 4x", () => {
-      expect(given.chainLeft(x => Left.of(4 * x)).value).toBe(5);
+      expect(given.chain(x => Either.left(4 * x), "left").fold(value)).toBe(5);
     });
     it("chain left over function right 4x", () => {
-      expect(given.chainLeft(x => Right.of(4 * x)).value).toBe(5);
+      expect(given.chain(x => Either.right(4 * x), "left").fold(value)).toBe(5);
     });
   });
 });

--- a/src/either.spec.ts
+++ b/src/either.spec.ts
@@ -1,4 +1,4 @@
-import { Either } from "./either";
+import { Either, Left, Right } from "./either";
 
 const value = {
   left: (x: any): any => x,
@@ -6,7 +6,7 @@ const value = {
 };
 describe("either", () => {
   describe("left(4)", () => {
-    const given = Either.left(4);
+    const given = Left.of(4);
     it("should equal string left(4)", () => {
       expect(`${given}`).toEqual("left(4)");
     });
@@ -18,22 +18,20 @@ describe("either", () => {
       expect(given.map(x => 2 * x).fold(value)).toBe(4);
     });
     it("chain over function right 2x", () => {
-      expect(given.chain(x => Either.right(2 * x)).fold(value)).toBe(4);
+      expect(given.chain(x => Right.of(2 * x)).fold(value)).toBe(4);
     });
     it("chain over function left 3x", () => {
-      expect(given.chain(x => Either.left(3 * x)).fold(value)).toBe(4);
+      expect(given.chain(x => Left.of(3 * x)).fold(value)).toBe(4);
     });
     it("chain left over function left 4x", () => {
-      expect(given.chain(x => Either.left(4 * x), "left").fold(value)).toBe(16);
+      expect(given.chain(x => Left.of(4 * x), "left").fold(value)).toBe(16);
     });
     it("chain left over function right 4x", () => {
-      expect(given.chain(x => Either.right(4 * x), "left").fold(value)).toBe(
-        16
-      );
+      expect(given.chain(x => Right.of(4 * x), "left").fold(value)).toBe(16);
     });
   });
   describe("right(5)", () => {
-    const given = Either.right(5);
+    const given = Right.of(5);
     it("should equal string right(5)", () => {
       expect(`${given}`).toEqual("right(5)");
     });
@@ -45,16 +43,16 @@ describe("either", () => {
       expect(given.map(x => 2 * x).fold(value)).toBe(10);
     });
     it("chain over function right 3x", () => {
-      expect(given.chain(x => Either.right(3 * x)).fold(value)).toBe(15);
+      expect(given.chain(x => Right.of(3 * x)).fold(value)).toBe(15);
     });
     it("chain over function left 3x", () => {
-      expect(given.chain(x => Either.left(3 * x)).fold(value)).toBe(15);
+      expect(given.chain(x => Left.of(3 * x)).fold(value)).toBe(15);
     });
     it("chain left over function left 4x", () => {
-      expect(given.chain(x => Either.left(4 * x), "left").fold(value)).toBe(5);
+      expect(given.chain(x => Left.of(4 * x), "left").fold(value)).toBe(5);
     });
     it("chain left over function right 4x", () => {
-      expect(given.chain(x => Either.right(4 * x), "left").fold(value)).toBe(5);
+      expect(given.chain(x => Right.of(4 * x), "left").fold(value)).toBe(5);
     });
   });
 });

--- a/src/either.ts
+++ b/src/either.ts
@@ -1,56 +1,8 @@
-export abstract class Either<L, R> {
-  abstract fold<Co>(options: { left(l: L): Co; right(r: R): Co }): Co;
-  abstract readonly value: L | R;
-  defaultTo(fallback: R) {
-    return this.fold({
-      left: () => fallback,
-      right: x => x
-    });
-  }
-  map<R2>(mapFn: (r: R) => R2): Either<L, R2> {
-    return this.fold({
-      left: _ => this as any,
-      right: r => Right.of(mapFn(r))
-    });
-  }
-  chainLeft<L2>(mapFn: (r: L) => Either<L2, R>): Either<L2, R> {
-    return this.fold({
-      left: mapFn,
-      right: _ => this as any
-    });
-  }
-  chain<R2>(mapFn: (r: R) => Either<L, R2>): Either<L, R2> {
-    return this.fold({
-      left: _ => this as any,
-      right: mapFn
-    });
-  }
-}
-export class Right<L, R> extends Either<L, R> {
-  static of<R>(value: R) {
-    return new Right<any, R>(value);
-  }
-  constructor(readonly value: R) {
-    super();
-  }
-  fold<Co>(options: { left(l: L): Co; right(r: R): Co }): Co {
-    return options.right(this.value);
-  }
-  toString() {
-    return `right(${(this.value)})`;
-  }
-}
-export class Left<L, R> extends Either<L, R> {
-  static of<L>(value: L) {
-    return new Left<L, any>(value);
-  }
-  constructor(readonly value: L) {
-    super();
-  }
-  fold<Co>(options: { left(l: L): Co; right(r: R): Co }): Co {
-    return options.left(this.value);
-  }
-  toString() {
-    return `left(${(this.value)})`;
-  }
+import { MonadUnion } from "./monad";
+
+export class Either<L, R> extends MonadUnion<{ left: L; right: R }, "right"> {
+  static left = <L>(value: L): Either<L, any> =>
+    MonadUnion.of("right", "left", value);
+  static right = <R>(value: R): Either<any, R> =>
+    MonadUnion.of("right", "right", value);
 }

--- a/src/either.ts
+++ b/src/either.ts
@@ -1,8 +1,16 @@
-import { MonadUnion } from "./monad";
+import {MonadUnion} from './monad';
 
-export class Either<L, R> extends MonadUnion<{ left: L; right: R }, "right"> {
+export class Either<L, R> extends MonadUnion<{left: L; right: R}, 'right'> {
   static left = <L>(value: L): Either<L, any> =>
-    MonadUnion.of("right", "left", value);
+    MonadUnion.of('right', 'left', value);
   static right = <R>(value: R): Either<any, R> =>
-    MonadUnion.of("right", "right", value);
+    MonadUnion.of('right', 'right', value);
 }
+
+export const Right = {
+  of: Either.right,
+};
+
+export const Left = {
+  of: Either.left,
+};

--- a/src/matches.gen.ts
+++ b/src/matches.gen.ts
@@ -441,6 +441,7 @@ export const testSetup = fc.array(matcherPairs).chain(matcherPairsSets => {
     defaultValue,
     setupInformation: [] as [],
     runMatch: (x: unknown) => matches(x).defaultTo(defaultValue),
+    runMatchLazy: (x: unknown) => matches(x).defaultToLazy(() => defaultValue),
     randomExample: {
       value: defaultValue,
       counter: noPossibleCounter as any,
@@ -472,6 +473,14 @@ export const testSetup = fc.array(matcherPairs).chain(matcherPairsSets => {
             matches(x)
           )
           .defaultTo(defaultValue),
+      runMatchLazy: (x: unknown) =>
+        setupInformation
+          .reduce(
+            (acc: ChainMatches<unknown>, { matcher, matchValue }) =>
+              acc.when(matcher, () => matchValue),
+            matches(x)
+          )
+          .defaultToLazy(() => defaultValue),
       randomExample: {
         value: setupInformation[randomExampleIndex].example,
         counter: setupInformation[randomExampleIndex].counterExample,

--- a/src/matches.gen.ts
+++ b/src/matches.gen.ts
@@ -22,160 +22,242 @@ type MatchPair<A> = {
   type: string;
   counterExample: any;
 };
-const trueFloat = fc
-  .tuple(fc.oneof(fc.constant(0), fc.float()), fc.integer())
-  .map(([x, y]) => x + y);
-const matcherNumber = fc
-  .record({
-    example: trueFloat,
-    counterExample: fc.oneof<any>(
-      fc.constantFrom(null, undefined),
-      fc.string(),
-      fc.object()
-    )
-  })
-  .map(({ example, counterExample }) =>
-    matchPairOf(matches.number, example, "number", counterExample)
-  );
-const matcherNill = fc
-  .record({
-    example: fc.constantFrom(null, undefined),
-    counterExample: fc.oneof<any>(fc.string(), fc.object(), fc.integer())
-  })
-  .map(({ example, counterExample }) =>
-    matchPairOf(matches.nill, example, "nill", counterExample)
-  );
-const matcherNat = fc
-  .record({
-    example: fc.nat(),
-    counterExample: fc.oneof<any>(
-      fc.constantFrom(null, undefined),
-      fc.string(),
-      fc.object(),
-      fc
-        .nat()
-        .filter(x => x !== 0)
-        .map(x => -x)
-    )
-  })
-  .map(({ example, counterExample }) =>
-    matchPairOf(matches.natural, example, "natural number", counterExample)
-  );
-const matcherObject = fc
-  .record({
-    example: fc.object(),
-    counterExample: fc.oneof<any>(
-      fc.constantFrom(null, undefined),
-      fc.string(),
-      trueFloat
-    )
-  })
-  .map(({ example, counterExample }) =>
-    matchPairOf(matches.object, example, "object", counterExample)
-  );
-
-fc.boolean(), fc.integer(), fc.string();
-const matcherConstant = fc
-  .oneof<{ example: boolean | string | number; counterExample: any }>(
-    fc.record({
-      example: fc.boolean(),
+const matcherPairsSimple = (() => {
+  const trueFloat = fc
+    .tuple(fc.oneof(fc.constant(0), fc.float()), fc.integer())
+    .map(([x, y]) => x + y);
+  const matcherNumber = fc
+    .record({
+      example: trueFloat,
+      counterExample: fc.oneof<any>(
+        fc.constantFrom(null, undefined),
+        fc.string(),
+        fc.object()
+      )
+    })
+    .map(({ example, counterExample }) =>
+      matchPairOf(matches.number, example, "number", counterExample)
+    );
+  const matcherNill = fc
+    .record({
+      example: fc.constantFrom(null, undefined),
+      counterExample: fc.oneof<any>(fc.string(), fc.object(), fc.integer())
+    })
+    .map(({ example, counterExample }) =>
+      matchPairOf(matches.nill, example, "nill", counterExample)
+    );
+  const matcherNat = fc
+    .record({
+      example: fc.nat(),
+      counterExample: fc.oneof<any>(
+        fc.constantFrom(null, undefined),
+        fc.string(),
+        fc.object(),
+        fc
+          .nat()
+          .filter(x => x !== 0)
+          .map(x => -x)
+      )
+    })
+    .map(({ example, counterExample }) =>
+      matchPairOf(matches.natural, example, "natural number", counterExample)
+    );
+  const matcherObject = fc
+    .record({
+      example: fc.object(),
       counterExample: fc.oneof<any>(
         fc.constantFrom(null, undefined),
         fc.string(),
         trueFloat
       )
-    }),
-    fc.record({
-      example: fc.string(),
-      counterExample: fc.oneof<any>(
-        fc.constantFrom(null, undefined),
-        trueFloat,
-        fc.boolean()
-      )
-    }),
-    fc.record({
-      example: trueFloat,
+    })
+    .map(({ example, counterExample }) =>
+      matchPairOf(matches.object, example, "object", counterExample)
+    );
+
+  fc.boolean(), fc.integer(), fc.string();
+  const matcherFunction = fc
+    .record({
+      example: fc.constant(() => {}),
       counterExample: fc.oneof<any>(
         fc.constantFrom(null, undefined),
         fc.string(),
-        fc.boolean()
+        fc.object(),
+        trueFloat
       )
     })
-  )
-  .map(({ example, counterExample }) =>
-    matchPairOf(
-      matches.literal(example),
-      example,
-      `literal of ${JSON.stringify(example)}`,
-      counterExample
-    )
-  );
-const matcherFunction = fc
-  .record({
-    example: fc.constant(() => {}),
-    counterExample: fc.oneof<any>(
-      fc.constantFrom(null, undefined),
-      fc.string(),
-      fc.object(),
-      trueFloat
-    )
-  })
-  .map(({ example, counterExample }) =>
-    matchPairOf(matches.isFunction, example, "function", counterExample)
-  );
-const matcherBoolean = fc
-  .record({
-    example: fc.boolean(),
-    counterExample: fc.oneof<any>(
-      fc.constantFrom(null, undefined),
-      fc.string(),
-      fc.object(),
-      trueFloat
-    )
-  })
-  .map(({ example, counterExample }) =>
-    matchPairOf(matches.boolean, example, "boolean", counterExample)
-  );
-const matcherArray = fc
-  .record({
-    example: fc.array(fc.anything()),
-    counterExample: fc.oneof<any>(
-      fc.constantFrom(null, undefined, {}),
-      fc.string(),
-      trueFloat
-    )
-  })
-  .map(({ example, counterExample }) =>
-    matchPairOf(matches.array, example, "array", counterExample)
-  );
-const matcherAny = fc
-  .anything()
-  .map(x => matchPairOf(matches.any, x, "any", noPossibleCounter));
-const matcherString = fc
-  .record({
-    example: fc.string(),
-    counterExample: fc.oneof<any>(
-      fc.constantFrom(null, undefined),
-      fc.object(),
-      trueFloat
-    )
-  })
-  .map(({ example, counterExample }) =>
-    matchPairOf(matches.string, example, "string", counterExample)
-  );
+    .map(({ example, counterExample }) =>
+      matchPairOf(matches.isFunction, example, "function", counterExample)
+    );
+  const matcherBoolean = fc
+    .record({
+      example: fc.boolean(),
+      counterExample: fc.oneof<any>(
+        fc.constantFrom(null, undefined),
+        fc.string(),
+        fc.object(),
+        trueFloat
+      )
+    })
+    .map(({ example, counterExample }) =>
+      matchPairOf(matches.boolean, example, "boolean", counterExample)
+    );
+  const matcherArray = fc
+    .record({
+      example: fc.array(fc.anything()),
+      counterExample: fc.oneof<any>(
+        fc.constantFrom(null, undefined, {}),
+        fc.string(),
+        trueFloat
+      )
+    })
+    .map(({ example, counterExample }) =>
+      matchPairOf(matches.array, example, "array", counterExample)
+    );
+  const matcherAny = fc
+    .anything()
+    .map(x => matchPairOf(matches.any, x, "any", noPossibleCounter));
+  const matcherString = fc
+    .record({
+      example: fc.string(),
+      counterExample: fc.oneof<any>(
+        fc.constantFrom(null, undefined),
+        fc.object(),
+        trueFloat
+      )
+    })
+    .map(({ example, counterExample }) =>
+      matchPairOf(matches.string, example, "string", counterExample)
+    );
 
-const matcherPairsSimple = fc.oneof<MatchPair<any>>(
-  matcherNumber,
-  matcherFunction,
-  matcherObject,
-  matcherConstant,
-  matcherBoolean,
-  matcherArray,
-  matcherAny,
-  matcherString,
-  matcherNat,
-  matcherNill
-);
+  const matcherConstant = fc
+    .oneof<{ example: boolean | string | number; counterExample: any }>(
+      fc.record({
+        example: fc.boolean(),
+        counterExample: fc.oneof<any>(
+          fc.constantFrom(null, undefined),
+          fc.string(),
+          trueFloat
+        )
+      }),
+      fc.record({
+        example: fc.string(),
+        counterExample: fc.oneof<any>(
+          fc.constantFrom(null, undefined),
+          trueFloat,
+          fc.boolean()
+        )
+      }),
+      fc.record({
+        example: trueFloat,
+        counterExample: fc.oneof<any>(
+          fc.constantFrom(null, undefined),
+          fc.string(),
+          fc.boolean()
+        )
+      })
+    )
+    .map(({ example, counterExample }) =>
+      matchPairOf(
+        matches.literal(example),
+        example,
+        `literal of ${JSON.stringify(example)}`,
+        counterExample
+      )
+    );
+
+  const matchesLiteral = fc
+    .oneof<{ example: boolean | string | number; counterExample: any }>(
+      fc.record({
+        example: fc.boolean(),
+        counterExample: fc.oneof<any>(
+          fc.constantFrom(null, undefined),
+          fc.string(),
+          trueFloat
+        )
+      }),
+      fc.record({
+        example: fc.string(),
+        counterExample: fc.oneof<any>(
+          fc.constantFrom(null, undefined),
+          trueFloat,
+          fc.boolean()
+        )
+      }),
+      fc.record({
+        example: trueFloat,
+        counterExample: fc.oneof<any>(
+          fc.constantFrom(null, undefined),
+          fc.string(),
+          fc.boolean()
+        )
+      })
+    )
+    .map(({ example, counterExample }) =>
+      matchPairOf(
+        matches.literal(example),
+        example,
+        `literal of ${JSON.stringify(example)}`,
+        counterExample
+      )
+    );
+  type Constructor<A> = {
+    new (...args: any[]): A;
+  };
+  class TestBase {}
+  const constructors: Constructor<any>[] = [
+    class Test {},
+    class Test2 extends TestBase {},
+    class Test3 {}
+  ];
+
+  const matcherInstanceOf = fc
+    .constantFrom(...constructors)
+    .chain(Cons =>
+      fc.record({
+        example: fc.constant(new Cons()),
+        matcher: fc.constant(matches.instanceOf(Cons)),
+        type: fc.constant(`instanceOf ${Cons.name}`),
+        counterExample: fc.constantFrom(...constructors.filter(x => x != Cons))
+      })
+    )
+    .map(base =>
+      matchPairOf(base.matcher, base.example, base.type, base.counterExample)
+    );
+  return fc.oneof<MatchPair<any>>(
+    matcherNumber,
+    matcherFunction,
+    matcherInstanceOf,
+    matcherObject,
+    matcherConstant,
+    matcherBoolean,
+    matchesLiteral,
+    matcherArray,
+    matcherAny,
+    matcherString,
+    matcherNat,
+    matcherNill
+  );
+})();
+
+const matcherSome = fc
+  .array(matcherPairsSimple)
+  .filter(x => x.length > 0)
+  .chain(matchers =>
+    fc.integer(0, matchers.length - 1).map(atIndex => ({
+      atIndex,
+      matchers
+    }))
+  )
+  .map(({ atIndex, matchers }) => {
+    return matchPairOf(
+      matches.some(...matchers.map(x => x.matcher)),
+      matchers[atIndex].example,
+      `some (${matchers.map(x => x.type).join(", ")})`,
+      noPossibleCounter
+    );
+  });
+
 const matcherArrayOf = matcherPairsSimple.chain(pair =>
   fc.array(fc.constant(pair)).map(pairs => {
     const validCounter =
@@ -189,6 +271,7 @@ const matcherArrayOf = matcherPairsSimple.chain(pair =>
     );
   })
 );
+
 const matcherTuple = fc
   .array(matcherPairsSimple)
   .filter(x => x.length > 0)
@@ -197,11 +280,12 @@ const matcherTuple = fc
       !!xs.length && xs.every(x => x.counterExample !== noPossibleCounter);
     return matchPairOf(
       matches.tuple(xs.map(tupleValue => tupleValue.matcher) as any),
-      xs.map(x => x.example),
+      xs.map(x => x.example) as any,
       `tuple ${JSON.stringify(xs.map(x => x.type))}`,
       validCounter ? xs.map(x => x.counterExample) : 0
     );
   });
+
 const matcherShape = fc.dictionary(fc.string(), matcherPairsSimple).map(x => {
   type testingShape = { [key in keyof typeof x]: (typeof x)[key]["example"] };
   const matcher: Validator<testingShape> = matches.shape(
@@ -256,6 +340,7 @@ const matcherShape = fc.dictionary(fc.string(), matcherPairsSimple).map(x => {
 
   return matchPairOf(matcher, example, type, validCounter ? counterExample : 0);
 });
+
 const matcherShapePartial = fc
   .dictionary(fc.string(), matcherPairsSimple)
   .map(x => {
@@ -323,7 +408,8 @@ export const matcherPairs = fc.oneof<ReturnType<typeof matchPairOf>>(
   matcherShape,
   matcherTuple,
   matcherArrayOf,
-  matcherShapePartial
+  matcherShapePartial,
+  matcherSome
 );
 
 export const testSetupInformation = <A>(

--- a/src/matches.spec.ts
+++ b/src/matches.spec.ts
@@ -1,4 +1,4 @@
-import matches, { Maybe, Either } from "./matches";
+import matches, { Right, Left, Some, None } from "./matches";
 import fc from "fast-check";
 import * as gens from "./matches.gen";
 
@@ -64,6 +64,18 @@ describe("matches", () => {
         })
       );
     });
+    test("a matched lazy case will always be the equal to matcher or less than", () => {
+      fc.assert(
+        fc.property(gens.testSetup, testSetup => {
+          const indexOfMatchedValue = (value: any) =>
+            testSetup.setupInformation.map(x => x.matchValue).indexOf(value);
+          const foundIndex = indexOfMatchedValue(
+            testSetup.runMatchLazy(testSetup.randomExample.value)
+          );
+          expect(foundIndex).toBeLessThanOrEqual(testSetup.randomExample.index);
+        })
+      );
+    });
     test("a counter matched case will never be the equal to matcher", () => {
       fc.assert(
         fc.property(gens.testSetup, testSetup => {
@@ -71,6 +83,20 @@ describe("matches", () => {
             testSetup.setupInformation.map(x => x.matchValue).indexOf(value);
           const foundIndex = indexOfMatchedValue(
             testSetup.runMatch(testSetup.randomExample.counter)
+          );
+          if (testSetup.randomExample.counter !== gens.noPossibleCounter) {
+            expect(foundIndex).not.toEqual(testSetup.randomExample.index);
+          }
+        })
+      );
+    });
+    test("a counter matched lazy case will never be the equal to matcher", () => {
+      fc.assert(
+        fc.property(gens.testSetup, testSetup => {
+          const indexOfMatchedValue = (value: any) =>
+            testSetup.setupInformation.map(x => x.matchValue).indexOf(value);
+          const foundIndex = indexOfMatchedValue(
+            testSetup.runMatchLazy(testSetup.randomExample.counter)
           );
           if (testSetup.randomExample.counter !== gens.noPossibleCounter) {
             expect(foundIndex).not.toEqual(testSetup.randomExample.index);
@@ -180,6 +206,22 @@ describe("matches", () => {
               .indexOf(value as any);
           const foundIndex = indexOfMatchedValue(
             testSetup.runMatch(testSetup.randomExample.value)
+          );
+          if (testSetup.randomExample.index > -1) {
+            expect(foundIndex).toBeGreaterThanOrEqual(0);
+          }
+        })
+      );
+    });
+    test("a matched lazy value will not go to default", () => {
+      fc.assert(
+        fc.property(gens.testSetup, testSetup => {
+          const indexOfMatchedValue = (value: unknown) =>
+            testSetup.setupInformation
+              .map(x => x.matchValue)
+              .indexOf(value as any);
+          const foundIndex = indexOfMatchedValue(
+            testSetup.runMatchLazy(testSetup.randomExample.value)
           );
           if (testSetup.randomExample.index > -1) {
             expect(foundIndex).toBeGreaterThanOrEqual(0);
@@ -569,22 +611,22 @@ describe("matches", () => {
 
       test("a number in", () => {
         const input = 4;
-        const expected = Either.right(Maybe.some(4));
+        const expected = Right.of(Some.of(4));
         expect("" + maybeNumber.apply(input)).toBe("" + expected);
       });
       test("a null in", () => {
         const input = null;
-        const expected = Either.right(Maybe.none);
+        const expected = Right.of(None.of);
         expect("" + maybeNumber.apply(input)).toBe("" + expected);
       });
       test("a undefined in", () => {
         const input = undefined;
-        const expected = Either.right(Maybe.none);
+        const expected = Right.of(None.of);
         expect("" + maybeNumber.apply(input)).toBe("" + expected);
       });
       test("a object in", () => {
         const input = {};
-        const expected = Either.left("isNumber([object Object])");
+        const expected = Left.of("isNumber([object Object])");
         expect("" + maybeNumber.apply(input)).toBe("" + expected);
       });
     });
@@ -594,22 +636,22 @@ describe("matches", () => {
 
       test("a number in", () => {
         const input = 4;
-        const expected = Either.right(4);
+        const expected = Right.of(4);
         expect("" + maybeNumber.apply(input)).toBe("" + expected);
       });
       test("a null in", () => {
         const input = null;
-        const expected = Either.right(0);
+        const expected = Right.of(0);
         expect("" + maybeNumber.apply(input)).toBe("" + expected);
       });
       test("a undefined in", () => {
         const input = undefined;
-        const expected = Either.right(0);
+        const expected = Right.of(0);
         expect("" + maybeNumber.apply(input)).toBe("" + expected);
       });
       test("a object in", () => {
         const input = {};
-        const expected = Either.left("isNumber([object Object])");
+        const expected = Left.of("isNumber([object Object])");
         expect("" + maybeNumber.apply(input)).toBe("" + expected);
       });
     });

--- a/src/matches.spec.ts
+++ b/src/matches.spec.ts
@@ -1,9 +1,13 @@
-import matches, { Some, Right, None, Left } from "./matches";
+import matches, { Maybe, Either } from "./matches";
 import fc from "fast-check";
 import * as gens from "./matches.gen";
 
 const isNumber = (x: unknown): x is number => typeof x === "number";
 
+const unFold = {
+  left: (x: any): any => x,
+  right: (x: any): any => x
+};
 describe("matches", () => {
   describe("base", () => {
     test("testing catches", () => {
@@ -74,11 +78,25 @@ describe("matches", () => {
         })
       );
     });
-    test("a matcher pair will always match it's example", () => {
+    test("a matcher pair will always be able to cast it's example", () => {
       fc.assert(
         fc.property(gens.matcherPairs, ({ example, matcher }) => {
           matcher.unsafeCast(example);
         })
+      );
+    });
+    test("a matcher pair will always be able to cast as promise it's example", () => {
+      fc.assert(
+        fc.asyncProperty(gens.matcherPairs, async ({ example, matcher }) => {
+          await matcher.castPromise(example);
+        })
+      );
+    });
+    test("a matcher pair will always test it's example", () => {
+      fc.assert(
+        fc.property(gens.matcherPairs, ({ example, matcher }) =>
+          matcher.test(example)
+        )
       );
     });
     test("a matcher pair will never match it's counter example and throws", () => {
@@ -93,7 +111,7 @@ describe("matches", () => {
         )
       );
     });
-    test("a matcher will always be a function to Either of the same type or string on error", () => {
+    test("a matcher will always be a function to Either of the same value or string on error", () => {
       fc.assert(
         fc.property(
           gens.matcherPairs,
@@ -106,6 +124,47 @@ describe("matches", () => {
               },
               right: (value: any) => {
                 expect(value).toEqual(example);
+              }
+            });
+          }
+        )
+      );
+    });
+    test("a matcher defaulted will always be a function to Either of the same type (not nil) or string on error", () => {
+      fc.assert(
+        fc.property(
+          gens.matcherPairs.filter(x => x.example != null),
+          fc.anything(),
+          (pair, example) => {
+            const matchedValue = pair.matcher
+              .defaultTo(pair.example)
+              .apply(example);
+            matchedValue.fold({
+              left: (value: any) => {
+                expect(typeof value).toBe("string");
+              },
+              right: (value: any) => {
+                expect(value).not.toEqual(null);
+                expect(value).not.toEqual(undefined);
+              }
+            });
+          }
+        )
+      );
+    });
+    test("a matcher will will fold will always match the matcher test", () => {
+      fc.assert(
+        fc.property(
+          gens.matcherPairs,
+          fc.anything(),
+          ({ matcher }, example) => {
+            const matchedValue = matcher.apply(example);
+            matchedValue.fold({
+              left: () => {
+                expect(matcher.test(example)).toBe(false);
+              },
+              right: () => {
+                expect(matcher.test(example)).toEqual(true);
               }
             });
           }
@@ -130,418 +189,435 @@ describe("matches", () => {
     });
   });
 
-  test("should be able to test shape", () => {
-    const testValue = { a: "c" };
-    const validator = matches.shape({ a: matches.literal("c") });
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be able to test shape with failure", () => {
-    const testValue = { a: "c" };
-    const validator = matches.shape({ a: matches.literal("b") });
-    expect(validator.apply(testValue).value).toMatchInlineSnapshot(
-      `"@a literal[b](c)"`
-    );
-  });
-
-  test("should be able to test shape with failure: not object", () => {
-    const testValue = 5;
-    const validator = matches.shape({ a: matches.literal("b") });
-    expect(validator.apply(testValue).value).toEqual(
-      `isObject(${JSON.stringify(testValue)})`
-    );
-  });
-
-  test("should be able to test shape with failure", () => {
-    const testValue = {};
-    const validator = matches.shape({
-      a: matches.literal("b"),
-      b: matches.literal("b")
+  describe("snapshot testing", () => {
+    test("should be able to test shape", () => {
+      const testValue = { a: "c" };
+      const validator = matches.shape({ a: matches.literal("c") });
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
     });
-    expect(validator.apply(testValue).value).toMatchInlineSnapshot(
-      `"@a literal[b](undefined)"`
-    );
-  });
 
-  test("should be able to test partial shape", () => {
-    const testValue = {};
-    const validator = matches.partial({ a: matches.literal("c") });
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be able to test partial shape failure", () => {
-    const testValue = { a: "a", b: "b" };
-    const validator = matches.partial({
-      a: matches.literal("c"),
-      b: matches.literal("c")
-    });
-    expect(validator.apply(testValue).value).toMatchInlineSnapshot(
-      `"(@a literal[c](a), @b literal[c](b))"`
-    );
-  });
-
-  test("should be able to test literal", () => {
-    const testValue = "a";
-    const validator = matches.literal("a");
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be able to test literal with failure", () => {
-    const testValue = "a";
-    const validator = matches.literal("b");
-    expect(validator.apply(testValue).value).toMatchInlineSnapshot(
-      `"literal[b](a)"`
-    );
-  });
-
-  test("should be able to test number", () => {
-    const testValue = 4;
-    const validator = matches.number;
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be able to test number with failure", () => {
-    const testValue = "a";
-    const validator = matches.number;
-    expect(validator.apply(testValue).value).toMatchInlineSnapshot(
-      `"isNumber(a)"`
-    );
-  });
-
-  test("should be able to test string", () => {
-    const testValue = "a";
-    const validator = matches.string;
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be able to test string with failure", () => {
-    const testValue = 5;
-    const validator = matches.string;
-    expect(validator.apply(testValue).value).toMatchInlineSnapshot(
-      `"string(5)"`
-    );
-  });
-
-  test("should be able to test regex", () => {
-    const testValue = /test/;
-    const validator = matches.regex;
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be able to test regex with failure", () => {
-    const testValue = "test";
-    const validator = matches.regex;
-    expect(validator.apply(testValue).value).toMatchInlineSnapshot(
-      `"regex(test)"`
-    );
-  });
-
-  test("should be able to test isFunction", () => {
-    const testValue = () => ({});
-    const validator = matches.isFunction;
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be able to test isFunction with failure", () => {
-    const testValue = "test";
-    const validator = matches.isFunction;
-    expect(validator.apply(testValue).value).toMatchInlineSnapshot(
-      `"isFunction(test)"`
-    );
-  });
-
-  test("should be able to test boolean", () => {
-    const testValue = true;
-    const validator = matches.boolean;
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be able to test boolean false", () => {
-    const testValue = false;
-    const validator = matches.boolean;
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be able to test boolean with failure", () => {
-    const testValue = 0;
-    const validator = matches.boolean;
-    expect(validator.apply(testValue).value).toMatchInlineSnapshot(
-      `"boolean(0)"`
-    );
-  });
-
-  test("should be able to test boolean falsy with failure", () => {
-    const testValue = "test";
-    const validator = matches.boolean;
-    expect(validator.apply(testValue).value).toMatchInlineSnapshot(
-      `"boolean(test)"`
-    );
-  });
-
-  test("should be able to test any", () => {
-    const testValue = 0;
-    const validator = matches.any;
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be able to test object", () => {
-    const testValue = {};
-    const validator = matches.object;
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be able to test object with failure", () => {
-    const testValue = 5;
-    const validator = matches.object;
-    expect(validator.apply(testValue).value).toEqual("isObject(5)");
-  });
-
-  test("should be able to test tuple(number, string)", () => {
-    const testValue = [4, "test"];
-    const validator = matches.tuple([matches.number, matches.string]);
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be able to test tuple(number, string) with failure", () => {
-    const testValue = ["bad", 5];
-    const validator = matches.tuple([matches.number, matches.string]);
-    expect(validator.apply(testValue).value).toMatchInlineSnapshot(
-      `"@0 isNumber(bad)"`
-    );
-  });
-
-  test("should be able to use matches.when", () => {
-    const testValue = 4;
-    const validator = matches.number;
-    expect(
-      matches(testValue)
-        .when(validator, () => true)
-        .defaultTo(false)
-    ).toEqual(true);
-  });
-
-  test("should be able to use matches.when fallback for the default to", () => {
-    const testValue = "5";
-    const validator = matches.number;
-    expect(
-      matches(testValue)
-        .when(validator, () => true)
-        .defaultTo(false)
-    ).toEqual(false);
-  });
-
-  test("should union several matchers", () => {
-    const testValue = 4;
-    const validator = matches.some(matches.number, matches.string);
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be fallible union several matchers", () => {
-    const testValue = false;
-    const validator = matches.some(matches.number, matches.string);
-    expect(validator.apply(testValue).value).toMatchInlineSnapshot(
-      `"some(isNumber(false), string(false))"`
-    );
-  });
-
-  test("should intersection several matchers", () => {
-    const testValue = 4;
-    const isEven = matches.guard(
-      (x: unknown) => isNumber(x) && x % 2 === 0,
-      "isEven"
-    );
-    const validator = matches.every(matches.number, isEven);
-    expect(validator.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should be fallible union several matchers", () => {
-    const testValue = 5;
-    const isEven = matches.guard(
-      (x: unknown) => isNumber(x) && x % 2 === 0,
-      "isEven"
-    );
-    const isGt6 = matches.guard((x: unknown) => isNumber(x) && x > 6, "isGt6");
-    const validator = matches.every(matches.number, isEven, isGt6);
-    expect(validator.apply(testValue).value).toMatchInlineSnapshot(
-      `"isEven(5)"`
-    );
-  });
-
-  test("should have array of test", () => {
-    const testValue = [5, 5, 5];
-    const arrayOf = matches.arrayOf(matches.literal(5));
-    expect(arrayOf.apply(testValue).value).toEqual(testValue);
-  });
-  test("should have array of test fail", () => {
-    const testValue = [5, 3, 2, 5, 5];
-    const arrayOf = matches.arrayOf(matches.literal(5));
-    expect(arrayOf.apply(testValue).value).toMatchInlineSnapshot(
-      `"@1 literal[5](3)"`
-    );
-  });
-
-  test("should refinement matchers", () => {
-    const testValue = 4;
-    const isEven = matches.number.refine(
-      (num: number) => num % 2 === 0,
-      "isEven"
-    );
-    expect(isEven.apply(testValue).value).toEqual(testValue);
-  });
-
-  test("should refinement matchers fail", () => {
-    const testValue = 4;
-    const isEven = matches.number.refine(
-      (num: number) => num % 2 === 0,
-      "isEven"
-    );
-    expect(isEven.apply(testValue).toString()).toMatchInlineSnapshot(
-      `"right(4)"`
-    );
-  });
-
-  test("should throw on invalid unsafe match throw", () => {
-    expect(() =>
-      matches.partial({}).unsafeCast(5)
-    ).toThrowErrorMatchingInlineSnapshot(`"Failed type: isObject(5)"`);
-  });
-  test("should throw on invalid unsafe match throw", async () => {
-    try {
-      await matches.partial({}).castPromise(5);
-      expect("never").toBe("called");
-    } catch (e) {
-      expect(e).toMatchInlineSnapshot(`"isObject(5)"`);
-    }
-  });
-  test("should throw on invalid unsafe match throw", async () => {
-    expect(await matches.literal(5).castPromise(5)).toBe(5);
-  });
-  test("some should only return the unique", () => {
-    expect(
-      matches
-        .some(matches.number, matches.literal("test"), matches.number)
-        .apply("hello").value
-    ).toBe("some(isNumber(hello), literal[test](hello))");
-  });
-  test("some should only return the unique", () => {
-    expect(
-      matches.some(matches.number, matches.number).apply("hello").value
-    ).toBe("isNumber(hello)");
-  });
-
-  test("should guard without a name", () => {
-    expect(matches.guard(x => Number(x) > 3).unsafeCast(6)).toBe(6);
-  });
-  test("should guard without a name failure", () => {
-    expect(
-      matches
-        .guard(x => Number(x) > 3)
-        .apply(2)
-        .toString()
-    ).toMatchInlineSnapshot(`"left(test(2))"`);
-  });
-
-  test("should be able to test is object for event", () => {
-    const event = new Event("test");
-    expect(matches.object.apply(event).value).toBe(event);
-  });
-
-  describe("testing is instance", () => {
-    class Fake {
-      constructor(readonly value: number) {}
-    }
-    it("should be able to validate it is a instance", () => {
-      const value = new Fake(3);
-      expect(matches.instanceOf(Fake).test(value)).toEqual(true);
-      expect(matches.instanceOf(Fake).apply(value).value)
-        .toMatchInlineSnapshot(`
-Fake {
-  "value": 3,
-}
-`);
-    });
-    it("should be able to validate it is not a instance", () => {
-      const value = {
-        value: 4
-      };
-      expect(matches.instanceOf(Fake).test(value)).toEqual(false);
-      expect(matches.instanceOf(Fake).apply(value).value).toMatchInlineSnapshot(
-        `"isFake([object Object])"`
+    test("should be able to test shape with failure", () => {
+      const testValue = { a: "c" };
+      const validator = matches.shape({ a: matches.literal("b") });
+      expect(validator.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"@a literal[b](c)"`
       );
     });
-  });
 
-  test("should fail on a circular object", () => {
-    const o: any = {};
-    o.o = o;
-    expect(matches.isFunction.apply(o).value).toMatchInlineSnapshot(
-      `"isFunction([object Object])"`
-    );
-  });
+    test("should be able to test shape with failure: not object", () => {
+      const testValue = 5;
+      const validator = matches.shape({ a: matches.literal("b") });
+      expect(validator.apply(testValue).fold(unFold)).toEqual(
+        `isObject(${JSON.stringify(testValue)})`
+      );
+    });
 
-  test("should be able to map validation", () => {
-    const testString = "test";
-    const event = new Event(testString);
-    const isEvent = matches.guard(
-      (x: unknown): x is Event => x instanceof Event,
-      "isEvent"
-    );
-    expect(isEvent.map(x => x.type).apply(event).value).toBe(testString);
-  });
+    test("should be able to test shape with failure", () => {
+      const testValue = {};
+      const validator = matches.shape({
+        a: matches.literal("b"),
+        b: matches.literal("b")
+      });
+      expect(validator.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"@a literal[b](undefined)"`
+      );
+    });
 
-  describe("with a number.maybe matcher", () => {
-    const maybeNumber = matches.number.maybe();
+    test("should be able to test partial shape", () => {
+      const testValue = {};
+      const validator = matches.partial({ a: matches.literal("c") });
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
 
-    test("a number in", () => {
-      const input = 4;
-      const expected = Right.of(Some.of(4));
-      expect("" + maybeNumber.apply(input)).toBe("" + expected);
+    test("should be able to test partial shape failure", () => {
+      const testValue = { a: "a", b: "b" };
+      const validator = matches.partial({
+        a: matches.literal("c"),
+        b: matches.literal("c")
+      });
+      expect(validator.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"(@a literal[c](a), @b literal[c](b))"`
+      );
     });
-    test("a null in", () => {
-      const input = null;
-      const expected = Right.of(None.of);
-      expect("" + maybeNumber.apply(input)).toBe("" + expected);
-    });
-    test("a undefined in", () => {
-      const input = undefined;
-      const expected = Right.of(None.of);
-      expect("" + maybeNumber.apply(input)).toBe("" + expected);
-    });
-    test("a object in", () => {
-      const input = {};
-      const expected = Left.of("isNumber([object Object])");
-      expect("" + maybeNumber.apply(input)).toBe("" + expected);
-    });
-  });
 
-  describe("with a number.defaultTo matcher", () => {
-    const maybeNumber = matches.number.defaultTo(0);
+    test("should be able to test literal", () => {
+      const testValue = "a";
+      const validator = matches.literal("a");
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
 
-    test("a number in", () => {
-      const input = 4;
-      const expected = Right.of(4);
-      expect("" + maybeNumber.apply(input)).toBe("" + expected);
+    test("should be able to test literal with failure", () => {
+      const testValue = "a";
+      const validator = matches.literal("b");
+      expect(validator.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"literal[b](a)"`
+      );
     });
-    test("a null in", () => {
-      const input = null;
-      const expected = Right.of(0);
-      expect("" + maybeNumber.apply(input)).toBe("" + expected);
-    });
-    test("a undefined in", () => {
-      const input = undefined;
-      const expected = Right.of(0);
-      expect("" + maybeNumber.apply(input)).toBe("" + expected);
-    });
-    test("a object in", () => {
-      const input = {};
-      const expected = Left.of("isNumber([object Object])");
-      expect("" + maybeNumber.apply(input)).toBe("" + expected);
-    });
-  });
 
-  describe("Testing as a filter", () => {
-    it("should be able to utilize the test in a filter for typing", () => {
-      expect([0, "hi", 5, {}].filter(matches.number.test)).toEqual([0, 5]);
+    test("should be able to test number", () => {
+      const testValue = 4;
+      const validator = matches.number;
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
+
+    test("should be able to test number with failure", () => {
+      const testValue = "a";
+      const validator = matches.number;
+      expect(validator.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"isNumber(a)"`
+      );
+    });
+
+    test("should be able to test string", () => {
+      const testValue = "a";
+      const validator = matches.string;
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
+
+    test("should be able to test string with failure", () => {
+      const testValue = 5;
+      const validator = matches.string;
+      expect(validator.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"string(5)"`
+      );
+    });
+
+    test("should be able to test regex", () => {
+      const testValue = /test/;
+      const validator = matches.regex;
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
+
+    test("should be able to test regex with failure", () => {
+      const testValue = "test";
+      const validator = matches.regex;
+      expect(validator.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"isRegExp(test)"`
+      );
+    });
+
+    test("should be able to test isFunction", () => {
+      const testValue = () => ({});
+      const validator = matches.isFunction;
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
+
+    test("should be able to test isFunction with failure", () => {
+      const testValue = "test";
+      const validator = matches.isFunction;
+      expect(validator.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"isFunction(test)"`
+      );
+    });
+
+    test("should be able to test boolean", () => {
+      const testValue = true;
+      const validator = matches.boolean;
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
+
+    test("should be able to test boolean false", () => {
+      const testValue = false;
+      const validator = matches.boolean;
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
+
+    test("should be able to test boolean with failure", () => {
+      const testValue = 0;
+      const validator = matches.boolean;
+      expect(validator.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"boolean(0)"`
+      );
+    });
+
+    test("should be able to test boolean falsy with failure", () => {
+      const testValue = "test";
+      const validator = matches.boolean;
+      expect(validator.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"boolean(test)"`
+      );
+    });
+
+    test("should be able to test any", () => {
+      const testValue = 0;
+      const validator = matches.any;
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
+
+    test("should be able to test object", () => {
+      const testValue = {};
+      const validator = matches.object;
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
+
+    test("should be able to test object with failure", () => {
+      const testValue = 5;
+      const validator = matches.object;
+      expect(validator.apply(testValue).fold(unFold)).toEqual("isObject(5)");
+    });
+
+    test("should be able to test tuple(number, string)", () => {
+      const testValue = [4, "test"];
+      const validator = matches.tuple([matches.number, matches.string]);
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
+
+    test("should be able to test tuple(number, string) with failure", () => {
+      const testValue = ["bad", 5];
+      const validator = matches.tuple([matches.number, matches.string]);
+      expect(validator.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"@0 isNumber(bad)"`
+      );
+    });
+
+    test("should be able to use matches.when", () => {
+      const testValue = 4;
+      const validator = matches.number;
+      expect(
+        matches(testValue)
+          .when(validator, () => true)
+          .defaultTo(false)
+      ).toEqual(true);
+    });
+
+    test("should be able to use matches.when fallback for the default to", () => {
+      const testValue = "5";
+      const validator = matches.number;
+      expect(
+        matches(testValue)
+          .when(validator, () => true)
+          .defaultTo(false)
+      ).toEqual(false);
+    });
+
+    test("should union several matchers", () => {
+      const testValue = 4;
+      const validator = matches.some(matches.number, matches.string);
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
+
+    test("should be fallible union several matchers", () => {
+      const testValue = false;
+      const validator = matches.some(matches.number, matches.string);
+      expect(validator.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"some(isNumber(false), string(false))"`
+      );
+    });
+
+    test("should intersection several matchers", () => {
+      const testValue = 4;
+      const isEven = matches.guard(
+        (x: unknown) => isNumber(x) && x % 2 === 0,
+        "isEven"
+      );
+      const validator = matches.every(matches.number, isEven);
+      expect(validator.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
+
+    test("should be fallible union several matchers", () => {
+      const testValue = 5;
+      const isEven = matches.guard(
+        (x: unknown) => isNumber(x) && x % 2 === 0,
+        "isEven"
+      );
+      const isGt6 = matches.guard(
+        (x: unknown) => isNumber(x) && x > 6,
+        "isGt6"
+      );
+      const validator = matches.every(matches.number, isEven, isGt6);
+      expect(validator.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"isEven(5)"`
+      );
+    });
+
+    test("should have array of test", () => {
+      const testValue = [5, 5, 5];
+      const arrayOf = matches.arrayOf(matches.literal(5));
+      expect(arrayOf.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
+    test("should have array of test fail", () => {
+      const testValue = [5, 3, 2, 5, 5];
+      const arrayOf = matches.arrayOf(matches.literal(5));
+      expect(arrayOf.apply(testValue).fold(unFold)).toMatchInlineSnapshot(
+        `"@1 literal[5](3)"`
+      );
+    });
+
+    test("should refinement matchers", () => {
+      const testValue = 4;
+      const isEven = matches.number.refine(
+        (num: number) => num % 2 === 0,
+        "isEven"
+      );
+      expect(isEven.apply(testValue).fold(unFold)).toEqual(testValue);
+    });
+
+    test("should refinement matchers fail", () => {
+      const testValue = 4;
+      const isEven = matches.number.refine(
+        (num: number) => num % 2 === 0,
+        "isEven"
+      );
+      expect(isEven.apply(testValue).toString()).toMatchInlineSnapshot(
+        `"right(4)"`
+      );
+    });
+
+    test("should throw on invalid unsafe match throw", () => {
+      expect(() =>
+        matches.partial({}).unsafeCast(5)
+      ).toThrowErrorMatchingInlineSnapshot(`"Failed type: isObject(5)"`);
+    });
+    test("should throw on invalid unsafe match throw", async () => {
+      try {
+        await matches.partial({}).castPromise(5);
+        expect("never").toBe("called");
+      } catch (e) {
+        expect(e).toMatchInlineSnapshot(`"isObject(5)"`);
+      }
+    });
+    test("should throw on invalid unsafe match throw", async () => {
+      expect(await matches.literal(5).castPromise(5)).toBe(5);
+    });
+    test("some should only return the unique", () => {
+      expect(
+        matches
+          .some(matches.number, matches.literal("test"), matches.number)
+          .apply("hello")
+          .fold(unFold)
+      ).toBe("some(isNumber(hello), literal[test](hello))");
+    });
+    test("some should only return the unique", () => {
+      expect(
+        matches
+          .some(matches.number, matches.number)
+          .apply("hello")
+          .fold(unFold)
+      ).toBe("isNumber(hello)");
+    });
+
+    test("should guard without a name", () => {
+      expect(matches.guard(x => Number(x) > 3).unsafeCast(6)).toBe(6);
+    });
+    test("should guard without a name failure", () => {
+      expect(
+        matches
+          .guard(x => Number(x) > 3)
+          .apply(2)
+          .toString()
+      ).toMatchInlineSnapshot(`"left(test(2))"`);
+    });
+
+    test("should be able to test is object for event", () => {
+      const event = new Event("test");
+      expect(matches.object.apply(event).fold(unFold)).toBe(event);
+    });
+
+    describe("testing is instance", () => {
+      class Fake {
+        constructor(readonly value: number) {}
+      }
+      it("should be able to validate it is a instance", () => {
+        const value = new Fake(3);
+        expect(matches.instanceOf(Fake).test(value)).toEqual(true);
+        expect(
+          matches
+            .instanceOf(Fake)
+            .apply(value)
+            .fold(unFold)
+        ).toEqual(value);
+      });
+      it("should be able to validate it is not a instance", () => {
+        const value = {
+          value: 4
+        };
+        expect(matches.instanceOf(Fake).test(value)).toEqual(false);
+        expect(
+          matches
+            .instanceOf(Fake)
+            .apply(value)
+            .fold(unFold)
+        ).toMatchInlineSnapshot(`"isFake([object Object])"`);
+      });
+    });
+
+    test("should fail on a circular object", () => {
+      const o: any = {};
+      o.o = o;
+      expect(matches.isFunction.apply(o).fold(unFold)).toMatchInlineSnapshot(
+        `"isFunction([object Object])"`
+      );
+    });
+
+    test("should be able to map validation", () => {
+      const testString = "test";
+      const event = new Event(testString);
+      const isEvent = matches.guard(
+        (x: unknown): x is Event => x instanceof Event,
+        "isEvent"
+      );
+      expect(
+        isEvent
+          .map(x => x.type)
+          .apply(event)
+          .fold(unFold)
+      ).toBe(testString);
+    });
+
+    describe("with a number.maybe matcher", () => {
+      const maybeNumber = matches.number.maybe();
+
+      test("a number in", () => {
+        const input = 4;
+        const expected = Either.right(Maybe.some(4));
+        expect("" + maybeNumber.apply(input)).toBe("" + expected);
+      });
+      test("a null in", () => {
+        const input = null;
+        const expected = Either.right(Maybe.none);
+        expect("" + maybeNumber.apply(input)).toBe("" + expected);
+      });
+      test("a undefined in", () => {
+        const input = undefined;
+        const expected = Either.right(Maybe.none);
+        expect("" + maybeNumber.apply(input)).toBe("" + expected);
+      });
+      test("a object in", () => {
+        const input = {};
+        const expected = Either.left("isNumber([object Object])");
+        expect("" + maybeNumber.apply(input)).toBe("" + expected);
+      });
+    });
+
+    describe("with a number.defaultTo matcher", () => {
+      const maybeNumber = matches.number.defaultTo(0);
+
+      test("a number in", () => {
+        const input = 4;
+        const expected = Either.right(4);
+        expect("" + maybeNumber.apply(input)).toBe("" + expected);
+      });
+      test("a null in", () => {
+        const input = null;
+        const expected = Either.right(0);
+        expect("" + maybeNumber.apply(input)).toBe("" + expected);
+      });
+      test("a undefined in", () => {
+        const input = undefined;
+        const expected = Either.right(0);
+        expect("" + maybeNumber.apply(input)).toBe("" + expected);
+      });
+      test("a object in", () => {
+        const input = {};
+        const expected = Either.left("isNumber([object Object])");
+        expect("" + maybeNumber.apply(input)).toBe("" + expected);
+      });
+    });
+
+    describe("Testing as a filter", () => {
+      it("should be able to utilize the test in a filter for typing", () => {
+        expect([0, "hi", 5, {}].filter(matches.number.test)).toEqual([0, 5]);
+      });
     });
   });
 });

--- a/src/matches.ts
+++ b/src/matches.ts
@@ -1,5 +1,5 @@
-import { Either } from "./either";
-import { Maybe } from "./maybe";
+import {Either, Right, Left} from './either';
+import {Maybe, Some, None} from './maybe';
 import {
   ChainMatches,
   Validator,
@@ -21,10 +21,10 @@ import {
   object,
   string,
   boolean,
-  instanceOf
-} from "./validators";
+  instanceOf,
+} from './validators';
 
-export { Either, Maybe };
+export {Either, Maybe, Some, None, Right, Left};
 
 class Matched<OutcomeType> implements ChainMatches<OutcomeType> {
   constructor(private value: OutcomeType) {}
@@ -53,7 +53,7 @@ class MatchMore<OutcomeType> implements ChainMatches<OutcomeType> {
     const testedValue = toValidEither.apply(this.a);
     return testedValue.fold<ChainMatches<OutcomeType>>({
       left: () => this,
-      right: value => new Matched<OutcomeType>(thenFn(value))
+      right: value => new Matched<OutcomeType>(thenFn(value)),
     });
   }
 
@@ -99,7 +99,7 @@ export const matches = Object.assign(
     any,
     boolean,
     nill: isNill,
-    instanceOf
+    instanceOf,
   }
 );
 export default matches;

--- a/src/matches.ts
+++ b/src/matches.ts
@@ -1,5 +1,5 @@
-import { Left, Right, Either } from "./either";
-import { None, Some, Maybe } from "./maybe";
+import { Either } from "./either";
+import { Maybe } from "./maybe";
 import {
   ChainMatches,
   Validator,
@@ -24,7 +24,7 @@ import {
   instanceOf
 } from "./validators";
 
-export { Left, Right, Either, None, Some, Maybe };
+export { Either, Maybe };
 
 class Matched<OutcomeType> implements ChainMatches<OutcomeType> {
   constructor(private value: OutcomeType) {}

--- a/src/maybe.spec.ts
+++ b/src/maybe.spec.ts
@@ -1,52 +1,72 @@
-import { Maybe, Some, None } from "./maybe";
-
+import { Maybe } from "./maybe";
+const value = {
+  some: (x: any): any => x,
+  none: (): any => null
+};
 describe("Maybe", () => {
   describe("None(4)", () => {
-    const given: Maybe<number> = None.of;
+    const given: Maybe<number> = Maybe.none;
+    it("should have string value none()", () => {
+      expect(`${given}`).toEqual("none()");
+    });
     it("should be able to default to a value", () => {
       const answer = 2;
       expect(given.defaultTo(answer)).toBe(answer);
     });
+    it("should be able to default to a value", () => {
+      const answer = 2;
+      expect(given.defaultLazy(() => answer)).toBe(answer);
+    });
     it("map over function 2x", () => {
-      expect(given.map(x => 2 * x).value).toBe(null);
+      expect(given.map(x => 2 * x).fold(value)).toBe(null);
     });
     it("chain over function Some 2x", () => {
-      expect(given.chain(x => Some.of(2 * x)).value).toBe(null);
+      expect(given.chain(x => Maybe.some(2 * x)).fold(value)).toBe(null);
     });
     it("chain over function None 3x", () => {
-      expect(given.chain(x => None.of).value).toBe(null);
+      expect(given.chain(x => Maybe.none).fold(value)).toBe(null);
     });
   });
   describe("Some(5)", () => {
-    const given: Maybe<number> = Some.of(5);
+    const given: Maybe<number> = Maybe.some(5);
+    it("should have string value some(5)", () => {
+      expect(`${given}`).toEqual("some(5)");
+    });
     it("should be able to default to a value", () => {
       const defaultValue = 6;
       expect(given.defaultTo(defaultValue)).toBe(5);
     });
+    it("should be able to default to a value", () => {
+      const defaultValue = 6;
+      expect(given.defaultLazy(() => defaultValue)).toBe(5);
+    });
     it("map will work over function  2x", () => {
-      expect(given.map(x => 2 * x).value).toBe(10);
+      expect(given.map(x => 2 * x).fold(value)).toBe(10);
     });
     it("chain over function Some 3x", () => {
-      expect(given.chain(x => Some.of(3 * x)).value).toBe(15);
+      expect(given.chain(x => Maybe.some(3 * x)).fold(value)).toBe(15);
     });
     it("chain over function None 3x", () => {
-      expect(given.chain(x => None.of).value).toBe(null);
+      expect(given.chain(x => Maybe.none).fold(value)).toBe(null);
     });
   });
   describe("Some(undefined)", () => {
-    const given: Maybe<number> = Some.of<number>(undefined);
+    const given: Maybe<number> = Maybe.some<number>(undefined);
+    it("should have string value none()", () => {
+      expect(`${given}`).toEqual("none()");
+    });
     it("should be able to default to a value", () => {
       const answer = 4;
       expect(given.defaultTo(answer)).toBe(answer);
     });
     it("map over function 2x", () => {
-      expect(given.map(x => 2 * x).value).toBe(null);
+      expect(given.map(x => 2 * x).fold(value)).toBe(null);
     });
     it("chain over function Some 2x", () => {
-      expect(given.chain(x => Some.of(2 * x)).value).toBe(null);
+      expect(given.chain(x => Maybe.some(2 * x)).fold(value)).toBe(null);
     });
     it("chain over function None 3x", () => {
-      expect(given.chain(x => None.of).value).toBe(null);
+      expect(given.chain(x => Maybe.none).fold(value)).toBe(null);
     });
   });
 });

--- a/src/maybe.spec.ts
+++ b/src/maybe.spec.ts
@@ -1,11 +1,11 @@
-import { Maybe } from "./maybe";
+import { Maybe, Some, None } from "./maybe";
 const value = {
   some: (x: any): any => x,
   none: (): any => null
 };
 describe("Maybe", () => {
   describe("None(4)", () => {
-    const given: Maybe<number> = Maybe.none;
+    const given: Maybe<number> = None.ofFn();
     it("should have string value none()", () => {
       expect(`${given}`).toEqual("none()");
     });
@@ -21,14 +21,14 @@ describe("Maybe", () => {
       expect(given.map(x => 2 * x).fold(value)).toBe(null);
     });
     it("chain over function Some 2x", () => {
-      expect(given.chain(x => Maybe.some(2 * x)).fold(value)).toBe(null);
+      expect(given.chain(x => Some.of(2 * x)).fold(value)).toBe(null);
     });
     it("chain over function None 3x", () => {
-      expect(given.chain(x => Maybe.none).fold(value)).toBe(null);
+      expect(given.chain(x => None.of).fold(value)).toBe(null);
     });
   });
   describe("Some(5)", () => {
-    const given: Maybe<number> = Maybe.some(5);
+    const given: Maybe<number> = Some.of(5);
     it("should have string value some(5)", () => {
       expect(`${given}`).toEqual("some(5)");
     });
@@ -44,14 +44,14 @@ describe("Maybe", () => {
       expect(given.map(x => 2 * x).fold(value)).toBe(10);
     });
     it("chain over function Some 3x", () => {
-      expect(given.chain(x => Maybe.some(3 * x)).fold(value)).toBe(15);
+      expect(given.chain(x => Some.of(3 * x)).fold(value)).toBe(15);
     });
     it("chain over function None 3x", () => {
-      expect(given.chain(x => Maybe.none).fold(value)).toBe(null);
+      expect(given.chain(x => None.of).fold(value)).toBe(null);
     });
   });
   describe("Some(undefined)", () => {
-    const given: Maybe<number> = Maybe.some<number>(undefined);
+    const given: Maybe<number> = Some.of<number>(undefined);
     it("should have string value none()", () => {
       expect(`${given}`).toEqual("none()");
     });
@@ -63,10 +63,10 @@ describe("Maybe", () => {
       expect(given.map(x => 2 * x).fold(value)).toBe(null);
     });
     it("chain over function Some 2x", () => {
-      expect(given.chain(x => Maybe.some(2 * x)).fold(value)).toBe(null);
+      expect(given.chain(x => Some.of(2 * x)).fold(value)).toBe(null);
     });
     it("chain over function None 3x", () => {
-      expect(given.chain(x => Maybe.none).fold(value)).toBe(null);
+      expect(given.chain(x => None.of).fold(value)).toBe(null);
     });
   });
 });

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -6,3 +6,12 @@ export class Maybe<A> extends MonadUnion<{ none: ""; some: A }, "some"> {
   static some = <A>(value: A | nill): Maybe<A> =>
     value == null ? Maybe.none : MonadUnion.of("some", "some", value);
 }
+
+export const Some = {
+  of: Maybe.some
+};
+
+export const None = {
+  of: Maybe.none,
+  ofFn: () => Maybe.none
+};

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1,55 +1,8 @@
-type nil = void | undefined | null;
+import { MonadUnion } from "./monad";
 
-export abstract class Maybe<A> {
-  abstract fold<Co>(options: { some(a: A): Co; none(): Co }): Co;
-  abstract readonly value: A | null;
-
-  defaultTo(defaultValue: A): A {
-    return this.fold({
-      none: () => defaultValue,
-      some: x => x
-    });
-  }
-  map<A2>(mapFn: (r: A) => nil | A2): Maybe<A2> {
-    return this.fold({
-      none: () => this as any,
-      some: a => Some.of(mapFn(a))
-    });
-  }
-  chain<A2>(mapFn: (r: A) => Maybe<A2>): Maybe<A2> {
-    return this.fold({
-      none: () => this as any,
-      some: a => mapFn(a)
-    });
-  }
-}
-export class None extends Maybe<any> {
-  readonly value = null;
-  static of: Maybe<any> = new None();
-  static ofFn<A>(): Maybe<A> {
-    return None.of;
-  }
-  fold<Co>(options: { some(a: any): Co; none(): Co }): Co {
-    return options.none();
-  }
-  toString() {
-    return `none`;
-  }
-}
-export class Some<A> extends Maybe<A> {
-  static of<A>(value: A | nil): Maybe<A> {
-    if (value == null) {
-      return None.of;
-    }
-    return new Some(value);
-  }
-  constructor(readonly value: A) {
-    super();
-  }
-  fold<Co>(options: { some(a: A): Co; none(): Co }): Co {
-    return options.some(this.value);
-  }
-  toString() {
-    return `some(${this.value})`;
-  }
+type nill = null | void | undefined;
+export class Maybe<A> extends MonadUnion<{ none: ""; some: A }, "some"> {
+  static none: Maybe<any> = MonadUnion.of("some", "none", "");
+  static some = <A>(value: A | nill): Maybe<A> =>
+    value == null ? Maybe.none : MonadUnion.of("some", "some", value);
 }

--- a/src/monad.ts
+++ b/src/monad.ts
@@ -1,0 +1,85 @@
+type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> &
+  U[keyof U];
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export class MonadUnion<A extends {}, DefaultKey extends keyof A> {
+  static of<A extends {}, Key extends keyof A, DefaultKey extends keyof A>(
+    defaultKey: DefaultKey,
+    key: Key,
+    value: A[Key]
+  ) {
+    return new MonadUnion<A, DefaultKey>(defaultKey, {
+      [key]: value
+    } as any);
+  }
+  protected constructor(
+    private readonly defaultKey: DefaultKey,
+    readonly value: AtLeastOne<A>
+  ) {}
+
+  fold<B>(folder: { [Key in keyof A]: (value: A[Key]) => B }) {
+    const firstKey: keyof A = Object.keys(this.value)[0] as any;
+    return folder[firstKey](this.value[firstKey]);
+  }
+
+  chain<
+    B extends Omit<A, Key> & { [K in Key]: A[K] } & { [key in keyof A]: any },
+    Key extends keyof A = DefaultKey
+  >(
+    fn: (value: A[Key]) => MonadUnion<B, DefaultKey>,
+    key: Key = this.defaultKey as any
+  ): MonadUnion<B, DefaultKey> {
+    if (key in this.value) {
+      return fn(this.value[key]);
+    }
+    return this as any;
+  }
+
+  map<
+    B extends Omit<A, Key> & { [K in Key]: A[K] } & { [key in keyof A]: any },
+    Key extends keyof A = DefaultKey
+  >(
+    fn: (value: A[Key]) => B[Key],
+    key: Key = this.defaultKey as any
+  ): MonadUnion<B, DefaultKey> {
+    if (key in this.value) {
+      return MonadUnion.of<B, Key, DefaultKey>(
+        this.defaultKey,
+        key,
+        fn(this.value[key])
+      );
+    }
+    return this as any;
+  }
+
+  defaultTo(defaultValue: A[DefaultKey]): A[DefaultKey];
+  defaultTo<Key extends keyof A>(defaultValue: A[Key], key: Key): A[Key];
+  defaultTo<Key extends keyof A>(
+    defaultValue: A[Key],
+    key = this.defaultKey
+  ): A[Key] {
+    if (key in this.value) {
+      return this.value[key] as any;
+    }
+    return defaultValue;
+  }
+
+  defaultLazy(defaultValue: () => A[DefaultKey]): A[DefaultKey];
+  defaultLazy<Key extends keyof A>(
+    defaultValue: () => A[Key],
+    key: Key
+  ): A[Key];
+  defaultLazy<Key extends keyof A>(
+    defaultValue: () => A[Key],
+    key = this.defaultKey
+  ): A[Key] {
+    if (key in this.value) {
+      return this.value[key] as any;
+    }
+    return defaultValue();
+  }
+
+  toString() {
+    const key: keyof A = Object.keys(this.value)[0] as any;
+    return `${key}(${this.value[key]})`;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,27 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@iamstarkov/listr-update-renderer@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@iamstarkov/listr-update-renderer/-/listr-update-renderer-0.4.1.tgz#d7c48092a2dcf90fd672b6c8b458649cb350c77e"
+  integrity sha512-IJyxQWsYDEkf8C8QthBn5N8tIUR9V9je6j3sMIpAkonaadjbvxmRC6RAhpa3RKxndhNnU2M6iNbtJwd7usQYIA==
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^2.3.0"
+    strip-ansi "^3.0.1"
+
+"@samverschueren/stream-to-observable@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
+  integrity sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==
+  dependencies:
+    any-observable "^0.3.0"
+
 "@types/jest@^23.3.1":
   version "23.3.9"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.9.tgz#c16b55186ee73ae65e001fbee69d392c51337ad1"
@@ -66,6 +87,11 @@ ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
+ansi-escapes@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+  integrity sha1-06ioOzGapneTZisT52HHkRQiMG4=
+
 ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
@@ -92,6 +118,11 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+any-observable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
+  integrity sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -154,6 +185,18 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
+
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
+  dependencies:
+    array-uniq "^1.0.1"
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+  integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -494,6 +537,20 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+caller-callsite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
+  integrity sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
+  dependencies:
+    callsites "^2.0.0"
+
+caller-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
+  integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
+  dependencies:
+    caller-callsite "^2.0.0"
+
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
@@ -516,7 +573,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -527,7 +584,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
@@ -555,6 +612,28 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+cli-cursor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+  integrity sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=
+  dependencies:
+    restore-cursor "^1.0.1"
+
+cli-cursor@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  integrity sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -609,6 +688,11 @@ combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^2.14.1, commander@^2.9.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
 commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
@@ -651,12 +735,33 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cosmiconfig@^5.0.2, cosmiconfig@^5.0.6:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.7.tgz#39826b292ee0d78eda137dfa3173bd1c21a43b04"
+  integrity sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==
+  dependencies:
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.0:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -688,6 +793,11 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.1.0"
     whatwg-url "^7.0.0"
 
+date-fns@^1.27.2:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
+  integrity sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==
+
 debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -702,6 +812,13 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -711,6 +828,11 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -757,6 +879,18 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+del@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
+  integrity sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=
+  dependencies:
+    globby "^6.1.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    p-map "^1.1.1"
+    pify "^3.0.0"
+    rimraf "^2.2.8"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -805,7 +939,19 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-error-ex@^1.2.0:
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+  integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
+
+end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+  dependencies:
+    once "^1.4.0"
+
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
@@ -832,7 +978,7 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -888,6 +1034,24 @@ execa@^0.7.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+exit-hook@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
+  integrity sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=
 
 exit@^0.1.2:
   version "0.1.2"
@@ -1014,6 +1178,14 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+figures@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  integrity sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -1048,6 +1220,11 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+  integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -1062,6 +1239,13 @@ find-up@^2.1.0:
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -1121,6 +1305,15 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+g-status@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/g-status/-/g-status-2.0.2.tgz#270fd32119e8fc9496f066fe5fe88e0a6bc78b97"
+  integrity sha512-kQoE9qH+T1AHKgSSD0Hkv98bobE90ILQcXAF4wvGgsr7uFqNvwmh8j+Lq3l0RVt3E3HjSbv2B9biEGcEtpHLCA==
+  dependencies:
+    arrify "^1.0.1"
+    matcher "^1.0.0"
+    simple-git "^1.85.0"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -1140,10 +1333,27 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
+get-own-enumerable-property-symbols@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
+  integrity sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
+
+get-stream@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -1188,6 +1398,17 @@ globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
+
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  integrity sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=
+  dependencies:
+    array-union "^1.0.1"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
@@ -1317,6 +1538,22 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+husky@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.1.4.tgz#92f61383527d2571e9586234e5864356bfaceaa9"
+  integrity sha512-cZjGpS7qsaBSo3fOMUuR7erQloX3l5XzL1v/RkIqU6zrQImDdU70z5Re9fGDp7+kbYlM2EtS4aYMlahBeiCUGw==
+  dependencies:
+    cosmiconfig "^5.0.6"
+    execa "^1.0.0"
+    find-up "^3.0.0"
+    get-stdin "^6.0.0"
+    is-ci "^1.2.1"
+    pkg-dir "^3.0.0"
+    please-upgrade-node "^3.1.1"
+    read-pkg "^4.0.1"
+    run-node "^1.0.0"
+    slash "^2.0.0"
+
 iconv-lite@0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
@@ -1338,6 +1575,14 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+import-fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
+  integrity sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
+  dependencies:
+    caller-path "^2.0.0"
+    resolve-from "^3.0.0"
+
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
@@ -1350,6 +1595,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -1417,7 +1667,7 @@ is-callable@^1.1.3, is-callable@^1.1.4:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
   integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
 
-is-ci@^1.0.10:
+is-ci@^1.0.10, is-ci@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
   integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
@@ -1461,6 +1711,11 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
+  integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -1489,6 +1744,11 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
   integrity sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
+
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
 is-finite@^1.0.0:
   version "1.0.2"
@@ -1521,6 +1781,13 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
+is-glob@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
+  integrity sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -1540,6 +1807,37 @@ is-number@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
   integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
 
+is-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
+is-observable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
+  integrity sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==
+  dependencies:
+    symbol-observable "^1.1.0"
+
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+  integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
+  integrity sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==
+  dependencies:
+    is-path-inside "^1.0.0"
+
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
+  dependencies:
+    path-is-inside "^1.0.1"
+
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -1557,12 +1855,22 @@ is-primitive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
+
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
   dependencies:
     has "^1.0.1"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -1982,7 +2290,7 @@ jest-util@^23.4.0:
     slash "^1.0.0"
     source-map "^0.6.0"
 
-jest-validate@^23.0.1, jest-validate@^23.6.0:
+jest-validate@^23.0.1, jest-validate@^23.5.0, jest-validate@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.6.0.tgz#36761f99d1ed33fcd425b4e4c5595d62b6597474"
   integrity sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==
@@ -2026,7 +2334,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.7.0:
+js-yaml@^3.7.0, js-yaml@^3.9.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
@@ -2075,6 +2383,11 @@ jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
   integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -2167,6 +2480,81 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lint-staged@^8.0.5:
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-8.0.5.tgz#8eeca1a213eaded09c4e217da455b6f432046034"
+  integrity sha512-QI2D6lw2teArlr2fmrrCIqHxef7mK2lKjz9e+aZSzFlk5rsy10rg97p3wA9H/vIFR3Fvn34fAgUktD/k896S2A==
+  dependencies:
+    "@iamstarkov/listr-update-renderer" "0.4.1"
+    chalk "^2.3.1"
+    commander "^2.14.1"
+    cosmiconfig "^5.0.2"
+    debug "^3.1.0"
+    dedent "^0.7.0"
+    del "^3.0.0"
+    execa "^1.0.0"
+    find-parent-dir "^0.3.0"
+    g-status "^2.0.2"
+    is-glob "^4.0.0"
+    is-windows "^1.0.2"
+    jest-validate "^23.5.0"
+    listr "^0.14.2"
+    lodash "^4.17.5"
+    log-symbols "^2.2.0"
+    micromatch "^3.1.8"
+    npm-which "^3.0.1"
+    p-map "^1.1.1"
+    path-is-inside "^1.0.2"
+    pify "^3.0.0"
+    please-upgrade-node "^3.0.2"
+    staged-git-files "1.1.2"
+    string-argv "^0.0.2"
+    stringify-object "^3.2.2"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+  integrity sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=
+
+listr-update-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz#344d980da2ca2e8b145ba305908f32ae3f4cc8a7"
+  integrity sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#8206f4cf6d52ddc5827e5fd14989e0e965933a35"
+  integrity sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.2.tgz#cbe44b021100a15376addfc2d79349ee430bfe14"
+  integrity sha512-vmaNJ1KlGuGWShHI35X/F8r9xxS0VTHh9GejVXwSN20fG5xpq3Jh4bJbnumoT6q5EDM/8/YP1z3YMtQbFmhuXw==
+  dependencies:
+    "@samverschueren/stream-to-observable" "^0.3.0"
+    is-observable "^1.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.4.0"
+    listr-verbose-renderer "^0.4.0"
+    p-map "^1.1.1"
+    rxjs "^6.1.0"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -2186,15 +2574,54 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4:
+lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  integrity sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
+  dependencies:
+    chalk "^1.0.0"
+
+log-symbols@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
+  dependencies:
+    chalk "^2.0.1"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  integrity sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
+
+log-update@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
+  integrity sha1-iDKP19HOeTiykoN0bwsbwSayRwg=
+  dependencies:
+    ansi-escapes "^3.0.0"
+    cli-cursor "^2.0.0"
+    wrap-ansi "^3.0.1"
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -2242,6 +2669,13 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+matcher@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/matcher/-/matcher-1.1.1.tgz#51d8301e138f840982b338b116bb0c09af62c1c2"
+  integrity sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==
+  dependencies:
+    escape-string-regexp "^1.0.4"
+
 math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
@@ -2285,7 +2719,7 @@ micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.4:
+micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -2419,6 +2853,11 @@ needle@^2.2.1:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -2488,12 +2927,28 @@ npm-packlist@^1.1.6:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
 
+npm-path@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64"
+  integrity sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==
+  dependencies:
+    which "^1.2.10"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  integrity sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.1.2"
@@ -2520,7 +2975,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -2569,12 +3024,24 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+onetime@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+  integrity sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=
+
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
+  dependencies:
+    mimic-fn "^1.0.0"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -2635,6 +3102,13 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
+  integrity sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -2642,10 +3116,27 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
+
+p-map@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+  integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
+  integrity sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -2663,6 +3154,14 @@ parse-json@^2.2.0:
   integrity sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
   dependencies:
     error-ex "^1.2.0"
+
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 parse5@4.0.0:
   version "4.0.0"
@@ -2691,7 +3190,12 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-key@^2.0.0:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+  integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
+
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
@@ -2720,6 +3224,11 @@ pify@^2.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
 
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -2738,6 +3247,20 @@ pkg-dir@^2.0.0:
   integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
   dependencies:
     find-up "^2.1.0"
+
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+  dependencies:
+    find-up "^3.0.0"
+
+please-upgrade-node@^3.0.2, please-upgrade-node@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
+  integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
+  dependencies:
+    semver-compare "^1.0.0"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -2800,6 +3323,14 @@ psl@^1.1.24:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
   integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
 
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -2855,6 +3386,15 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
+
+read-pkg@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
+  integrity sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
 
 readable-stream@^2.0.1, readable-stream@^2.0.6:
   version "2.3.6"
@@ -2992,12 +3532,28 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
+restore-cursor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+  integrity sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=
+  dependencies:
+    exit-hook "^1.0.0"
+    onetime "^1.0.0"
+
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
@@ -3008,6 +3564,18 @@ rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
   integrity sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==
+
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
+
+rxjs@^6.1.0:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
+  integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -3046,6 +3614,11 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0:
   version "5.5.1"
@@ -3099,6 +3672,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+simple-git@^1.85.0:
+  version "1.107.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.107.0.tgz#12cffaf261c14d6f450f7fdb86c21ccee968b383"
+  integrity sha512-t4OK1JRlp4ayKRfcW6owrWcRVLyHRUlhGd0uN6ZZTqfDq8a5XpcUdOKiGRNobHEuMtNqzp0vcJNvhYWwh5PsQA==
+  dependencies:
+    debug "^4.0.1"
+
 sisteransi@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
@@ -3108,6 +3688,16 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+  integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -3239,6 +3829,11 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
   integrity sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=
 
+staged-git-files@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.2.tgz#4326d33886dc9ecfa29a6193bf511ba90a46454b"
+  integrity sha512-0Eyrk6uXW6tg9PYkhi/V/J4zHp33aNyi2hOCmhFLqLTIhbgqWn5jlSzI+IU0VqrZq6+DbHcabQl/WP6P3BG0QA==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -3251,6 +3846,11 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+string-argv@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
+  integrity sha1-2sMECGkMIfPDYwo/86BYd73L1zY=
 
 string-length@^2.0.0:
   version "2.0.0"
@@ -3283,6 +3883,15 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-object@^3.2.2:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
+  dependencies:
+    get-own-enumerable-property-symbols "^3.0.0"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -3338,6 +3947,11 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+symbol-observable@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.2"
@@ -3441,6 +4055,11 @@ ts-jest@^23.1.4:
     mkdirp "0.x"
     semver "^5.5"
     yargs-parser "10.x"
+
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -3599,7 +4218,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.2.12, which@^1.2.9, which@^1.3.0:
+which@^1.2.10, which@^1.2.12, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -3630,6 +4249,14 @@ wrap-ansi@^2.0.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  integrity sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
Remove the fact that we pull from value, instead go with interface instead. We now use a row polymorphic disjoint union style monad instead of multiple types of monad. Makes less code.
Utilize the same methods to ensure that the monad type is shared between the either and maybe
Add more testing in the property testing to test 100% of the code with property tests.