### PR TITLE
Feat  literals smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Making the description type to convert the parser into something else, like JsonSchema or typescript types. This brings in the names, children, and extras for each.
 
+Moving several simple parsers into their own description and parsers. Useful for things like typescript that have primitives like strings, numbers, and booleans.
+
 ## [4.2.0] - 2021-04-03
 
 Adding in better matching capabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.0.0] - ??.??.??
+
+Making the description type to convert the parser into something else, like JsonSchema or typescript types. This brings in the names, children, and extras for each.
+
 ## [4.2.0] - 2021-04-03
 
 Adding in better matching capabilities.

--- a/src/matches.spec.ts
+++ b/src/matches.spec.ts
@@ -650,7 +650,7 @@ describe("matches", () => {
       expect(() =>
         matches.partial({}).unsafeCast(5)
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Failed type: Shape<{}>(5) given input 5"`
+        `"Failed type: Partial<{}>(5) given input 5"`
       );
     });
     test("should throw on invalid unsafe match throw", async () => {
@@ -659,7 +659,7 @@ describe("matches", () => {
         expect("never").toBe("called");
       } catch (e) {
         expect(e).toMatchInlineSnapshot(
-          `[TypeError: Failed type: Shape<{}>(5) given input 5]`
+          `[TypeError: Failed type: Partial<{}>(5) given input 5]`
         );
       }
     });

--- a/src/matches.spec.ts
+++ b/src/matches.spec.ts
@@ -384,7 +384,7 @@ describe("matches", () => {
       const testValue = "a";
       const validator = matches.number;
       expect(validator.parse(testValue, unFold)).toMatchInlineSnapshot(
-        `"isNumber(\\"a\\")"`
+        `"number(\\"a\\")"`
       );
     });
 
@@ -426,7 +426,7 @@ describe("matches", () => {
       const testValue = "test";
       const validator = matches.isFunction;
       expect(validator.parse(testValue, unFold)).toMatchInlineSnapshot(
-        `"isFunction(\\"test\\")"`
+        `"Function(\\"test\\")"`
       );
     });
 
@@ -473,7 +473,7 @@ describe("matches", () => {
     test("should be able to test object with failure", () => {
       const testValue = 5;
       const validator = matches.object;
-      expect(validator.parse(testValue, unFold)).toEqual("isObject(5)");
+      expect(validator.parse(testValue, unFold)).toEqual("object(5)");
     });
 
     test("should be able to test tuple(number, string)", () => {
@@ -486,7 +486,7 @@ describe("matches", () => {
       const testValue = ["bad", 5];
       const validator = matches.tuple([matches.number, matches.string]);
       expect(validator.parse(testValue, unFold)).toMatchInlineSnapshot(
-        `"[\\"0\\"]isNumber(\\"bad\\")"`
+        `"[\\"0\\"]number(\\"bad\\")"`
       );
     });
 
@@ -520,7 +520,7 @@ describe("matches", () => {
       const testValue = false;
       const validator = matches.some(matches.number, matches.string);
       expect(validator.parse(testValue, unFold)).toMatchInlineSnapshot(
-        `"Or<isNumber,...>(false)"`
+        `"Or<number,...>(false)"`
       );
     });
 
@@ -674,12 +674,12 @@ describe("matches", () => {
         matches
           .some(matches.number, matches.literal("test"), matches.number)
           .parse("hello", unFold)
-      ).toMatchInlineSnapshot(`"Or<isNumber,...>(\\"hello\\")"`);
+      ).toMatchInlineSnapshot(`"Or<number,...>(\\"hello\\")"`);
     });
     test("some should only return the unique", () => {
       expect(
         matches.some(matches.number, matches.number).parse("hello", unFold)
-      ).toMatchInlineSnapshot(`"Or<isNumber,...>(\\"hello\\")"`);
+      ).toMatchInlineSnapshot(`"Or<number,...>(\\"hello\\")"`);
     });
 
     test("should guard without a name", () => {
@@ -724,7 +724,7 @@ describe("matches", () => {
       const o: any = {};
       o.o = o;
       expect(matches.isFunction.parse(o, unFold)).toMatchInlineSnapshot(
-        `"isFunction([object Object])"`
+        `"Function([object Object])"`
       );
     });
 
@@ -784,7 +784,7 @@ describe("matches", () => {
         const input = {};
         expect(
           saferStringify(maybeNumber.parse(input, unFold))
-        ).toMatchInlineSnapshot(`"\\"Maybe<isNumber>({})\\""`);
+        ).toMatchInlineSnapshot(`"\\"Maybe<number>({})\\""`);
       });
     });
 
@@ -809,7 +809,7 @@ describe("matches", () => {
       test("a object in", () => {
         const input = {};
         expect(maybeNumber.parse(input, unFold)).toMatchInlineSnapshot(
-          `"Default<0,Maybe<isNumber>>({})"`
+          `"Default<0,Maybe<number>>({})"`
         );
       });
     });

--- a/src/matches.ts
+++ b/src/matches.ts
@@ -23,9 +23,9 @@ import {
   dictionary,
   literals,
 } from "./parsers";
-import { ParserNames } from "./parsers/interfaces";
+export { ParserNames, IParser } from "./parsers/interfaces";
 
-export { Parser as Validator, ValidatorError, ParserNames };
+export { Parser as Validator, ValidatorError };
 
 // prettier-ignore
 export type ValueOrFunction<In, Out> =

--- a/src/parsers/AnyParser.ts
+++ b/src/parsers/AnyParser.ts
@@ -1,0 +1,14 @@
+import { IParser, OnParse } from "./interfaces";
+
+export class AnyParser implements IParser<unknown, any> {
+  constructor(
+    readonly description = {
+      name: "Any",
+      children: [],
+      extras: [],
+    } as const
+  ) {}
+  parse<C, D>(a: unknown, onParse: OnParse<unknown, any, C, D>): C | D {
+    return onParse.parsed(a);
+  }
+}

--- a/src/parsers/ArrayOfParser.ts
+++ b/src/parsers/ArrayOfParser.ts
@@ -11,7 +11,7 @@ export class ArrayOfParser<A extends unknown[], B> implements IParser<A, B[]> {
   constructor(
     readonly parser: IParser<A[number], B>,
     readonly description = {
-      name: "Array",
+      name: "ArrayOf",
       children: [parser],
       extras: [],
     } as const

--- a/src/parsers/ArrayParser.ts
+++ b/src/parsers/ArrayParser.ts
@@ -1,0 +1,24 @@
+import { IParser, OnParse } from "./interfaces";
+import { isObject } from "./utils";
+
+export class ArrayParser implements IParser<unknown, Array<unknown>> {
+  constructor(
+    readonly description = {
+      name: "Array",
+      children: [],
+      extras: [],
+    } as const
+  ) {}
+  parse<C, D>(
+    a: unknown,
+    onParse: OnParse<unknown, Array<unknown>, C, D>
+  ): C | D {
+    if (Array.isArray(a)) return onParse.parsed(a);
+
+    return onParse.invalid({
+      value: a,
+      keys: [],
+      parser: this,
+    });
+  }
+}

--- a/src/parsers/BoolParser.ts
+++ b/src/parsers/BoolParser.ts
@@ -1,0 +1,21 @@
+import { isNumber } from ".";
+import { IParser, OnParse } from "./interfaces";
+
+export class BoolParser implements IParser<unknown, boolean> {
+  constructor(
+    readonly description = {
+      name: "Boolean",
+      children: [],
+      extras: [],
+    } as const
+  ) {}
+  parse<C, D>(a: unknown, onParse: OnParse<unknown, boolean, C, D>): C | D {
+    if (a === true || a === false) return onParse.parsed(a);
+
+    return onParse.invalid({
+      value: a,
+      keys: [],
+      parser: this,
+    });
+  }
+}

--- a/src/parsers/DictionaryParser.ts
+++ b/src/parsers/DictionaryParser.ts
@@ -45,7 +45,6 @@ export class DictionaryParser<
     const answer: any = { ...a };
     outer: for (const key in a) {
       let parseError: Array<ISimpleParsedError> = [];
-      console.log(parsers);
       for (const [keyParser, valueParser] of parsers) {
         const newError = keyParser.parse(key, {
           parsed(newKey: string | number) {

--- a/src/parsers/FunctionParser.ts
+++ b/src/parsers/FunctionParser.ts
@@ -1,0 +1,21 @@
+import { IParser, OnParse } from "./interfaces";
+import { isFunctionTest } from "./utils";
+
+export class FunctionParser implements IParser<unknown, Function> {
+  constructor(
+    readonly description = {
+      name: "Function",
+      children: [],
+      extras: [],
+    } as const
+  ) {}
+  parse<C, D>(a: unknown, onParse: OnParse<unknown, Function, C, D>): C | D {
+    if (isFunctionTest(a)) return onParse.parsed(a);
+
+    return onParse.invalid({
+      value: a,
+      keys: [],
+      parser: this,
+    });
+  }
+}

--- a/src/parsers/MappedAParser.ts
+++ b/src/parsers/MappedAParser.ts
@@ -7,7 +7,7 @@ export class MappedAParser<A, B, B2> implements IParser<A, B2> {
     readonly mappingName = map.name,
     readonly description = {
       name: "Mapped",
-      children: [],
+      children: [parent],
       extras: [mappingName],
     } as const
   ) {}

--- a/src/parsers/NillParser.ts
+++ b/src/parsers/NillParser.ts
@@ -1,0 +1,22 @@
+import { IParser, OnParse } from "./interfaces";
+export class NilParser implements IParser<unknown, null | undefined> {
+  constructor(
+    readonly description = {
+      name: "Null",
+      children: [],
+      extras: [],
+    } as const
+  ) {}
+  parse<C, D>(
+    a: unknown,
+    onParse: OnParse<unknown, null | undefined, C, D>
+  ): C | D {
+    if (a === null || a === undefined) return onParse.parsed(a);
+
+    return onParse.invalid({
+      value: a,
+      keys: [],
+      parser: this,
+    });
+  }
+}

--- a/src/parsers/NumberParser.ts
+++ b/src/parsers/NumberParser.ts
@@ -1,0 +1,21 @@
+import { isNumber } from ".";
+import { IParser, OnParse } from "./interfaces";
+
+export class NumberParser implements IParser<unknown, number> {
+  constructor(
+    readonly description = {
+      name: "Number",
+      children: [],
+      extras: [],
+    } as const
+  ) {}
+  parse<C, D>(a: unknown, onParse: OnParse<unknown, number, C, D>): C | D {
+    if (isNumber(a)) return onParse.parsed(a);
+
+    return onParse.invalid({
+      value: a,
+      keys: [],
+      parser: this,
+    });
+  }
+}

--- a/src/parsers/ObjectParser.ts
+++ b/src/parsers/ObjectParser.ts
@@ -1,0 +1,21 @@
+import { IParser, OnParse } from "./interfaces";
+import { isObject } from "./utils";
+
+export class ObjectParser implements IParser<unknown, object> {
+  constructor(
+    readonly description = {
+      name: "Object",
+      children: [],
+      extras: [],
+    } as const
+  ) {}
+  parse<C, D>(a: unknown, onParse: OnParse<unknown, object, C, D>): C | D {
+    if (isObject(a)) return onParse.parsed(a);
+
+    return onParse.invalid({
+      value: a,
+      keys: [],
+      parser: this,
+    });
+  }
+}

--- a/src/parsers/Parser.ts
+++ b/src/parsers/Parser.ts
@@ -1,8 +1,12 @@
 import { IsAParser } from ".";
 import { saferStringify } from "../utils";
+import { AnyParser } from "./AnyParser";
+import { ArrayParser } from "./ArrayParser";
+import { BoolParser } from "./BoolParser";
 import { ConcatParsers } from "./ConcatParser";
 import { DefaultParser } from "./DefaultParser";
 import { DictionaryParser } from "./DictionaryParser";
+import { FunctionParser } from "./FunctionParser";
 import { GuardParser } from "./GuardParser";
 import {
   IParser,
@@ -13,8 +17,12 @@ import {
 } from "./interfaces";
 import { MappedAParser } from "./MappedAParser";
 import { MaybeParser } from "./MaybeParser";
+import { NilParser } from "./NillParser";
+import { NumberParser } from "./NumberParser";
+import { ObjectParser } from "./ObjectParser";
 import { OrParsers } from "./OrParser";
 import { ShapeParser } from "./ShapeParser";
+import { StringParser } from "./StringParser";
 import { identity, booleanOnParse } from "./utils";
 
 function unwrapParser(a: IParser<unknown, unknown>): IParser<unknown, unknown> {
@@ -90,6 +98,24 @@ export class Parser<A, B> implements IParser<A, B> {
     }
     if (parser instanceof GuardParser) {
       return String(extras[0] || name);
+    }
+    if (
+      parser instanceof StringParser ||
+      parser instanceof ObjectParser ||
+      parser instanceof NumberParser ||
+      parser instanceof BoolParser ||
+      parser instanceof AnyParser
+    ) {
+      return name.toLowerCase();
+    }
+    if (parser instanceof FunctionParser) {
+      return name;
+    }
+    if (parser instanceof NilParser) {
+      return "null";
+    }
+    if (parser instanceof ArrayParser) {
+      return "Array<unknown>";
     }
     const specifiers = [
       ...extras.map(saferStringify),

--- a/src/parsers/ShapeParser.ts
+++ b/src/parsers/ShapeParser.ts
@@ -19,7 +19,7 @@ export class ShapeParser<
       string & keyof typeof parserMap
     >,
     readonly description = {
-      name: "Shape",
+      name: isPartial ? "Partial" : "Shape",
       children: parserKeys.map((key) => parserMap[key]),
       extras: parserKeys,
     } as const

--- a/src/parsers/ShapeParser.ts
+++ b/src/parsers/ShapeParser.ts
@@ -16,7 +16,7 @@ export class ShapeParser<
     readonly parserMap: { [key in keyof B]: Parser<unknown, B[key]> },
     readonly isPartial: boolean,
     readonly parserKeys = Object.keys(parserMap) as Array<
-      keyof typeof parserMap
+      string & keyof typeof parserMap
     >,
     readonly description = {
       name: "Shape",

--- a/src/parsers/SimpleParsers.ts
+++ b/src/parsers/SimpleParsers.ts
@@ -1,7 +1,12 @@
 import { Parser } from ".";
-import { saferStringify } from "../utils";
-import { isFunctionTest, isNumber, isObject, isString, OneOf } from "./utils";
-
+import { AnyParser } from "./AnyParser";
+import { ArrayParser } from "./ArrayParser";
+import { BoolParser } from "./BoolParser";
+import { FunctionParser } from "./FunctionParser";
+import { NilParser } from "./NillParser";
+import { NumberParser } from "./NumberParser";
+import { ObjectParser } from "./ObjectParser";
+import { StringParser } from "./StringParser";
 /**
  * Create a custom type guard
  * @param test A function that will determine runtime if the value matches
@@ -14,33 +19,25 @@ export function guard<A, B extends A>(
   return Parser.isA(test, testName || test.name);
 }
 
-export const any = guard((a: unknown): a is any => true, "any");
+export const any = new Parser(new AnyParser());
 
-export const number = guard(isNumber);
+export const number = new Parser(new NumberParser());
 
-export const isNill = guard(function isNill(x: unknown): x is null | undefined {
-  return x == null;
-});
+export const isNill = new Parser(new NilParser());
 
 export const natural = number.refine(
   (x): x is number => x >= 0 && x === Math.floor(x)
 );
 
-export const isFunction = guard<unknown, (...args: any[]) => any>(
-  (x): x is (...args: unknown[]) => unknown => isFunctionTest(x),
-  "isFunction"
-);
+export const isFunction = new Parser(new FunctionParser());
 
-export const boolean = guard(
-  (x): x is boolean => x === true || x === false,
-  "boolean"
-);
+export const boolean = new Parser(new BoolParser());
 
-export const object = guard(isObject);
+export const object = new Parser(new ObjectParser());
 
-export const isArray = guard<unknown, ArrayLike<unknown>>(Array.isArray);
+export const isArray = new Parser(new ArrayParser());
 
-export const string = guard((x): x is string => isString(x), "string");
+export const string = new Parser(new StringParser());
 export const instanceOf = <C>(classCreator: {
   new (...args: any[]): C;
 }): Parser<unknown, C> =>

--- a/src/parsers/StringParser.ts
+++ b/src/parsers/StringParser.ts
@@ -1,0 +1,21 @@
+import { IParser, OnParse } from "./interfaces";
+import { isString } from "./utils";
+
+export class StringParser implements IParser<unknown, string> {
+  constructor(
+    readonly description = {
+      name: "String",
+      children: [],
+      extras: [],
+    } as const
+  ) {}
+  parse<C, D>(a: unknown, onParse: OnParse<unknown, string, C, D>): C | D {
+    if (isString(a)) return onParse.parsed(a);
+
+    return onParse.invalid({
+      value: a,
+      keys: [],
+      parser: this,
+    });
+  }
+}

--- a/src/parsers/interfaces.ts
+++ b/src/parsers/interfaces.ts
@@ -26,7 +26,7 @@ export type Description = {
   readonly children: ReadonlyArray<SomeParser>;
 } & (
   | {
-      readonly name: "Array";
+      readonly name: "ArrayOf";
       readonly children: readonly [SomeParser];
       readonly extras: readonly [];
     }
@@ -80,10 +80,25 @@ export type Description = {
       readonly children: ReadonlyArray<SomeParser>;
       readonly extras: ReadonlyArray<string | number>;
     }
+  | {
+      readonly name:
+        | "Any"
+        | "Null"
+        | "Number"
+        | "Boolean"
+        | "Function"
+        | "String"
+        | "Object"
+        | "Array";
+      readonly children: readonly [];
+      readonly extras: readonly [];
+    }
 );
 
 export type ParserNames =
+  | "Any"
   | "Array"
+  | "ArrayOf"
   | "Concat"
   | "Default"
   | "Dictionary"
@@ -92,6 +107,12 @@ export type ParserNames =
   | "Mapped"
   | "Maybe"
   | "Named"
+  | "Number"
+  | "Boolean"
+  | "Function"
+  | "Object"
+  | "String"
+  | "Null"
   | "Or"
   | "Shape"
   | "Wrapper";

--- a/src/parsers/interfaces.ts
+++ b/src/parsers/interfaces.ts
@@ -8,28 +8,85 @@ export type Nil = null | undefined;
 
 export type Optional<A> = A | null | undefined;
 export type _<T> = T;
+export type SomeParser = IParser<unknown, unknown>;
 
 export type ISimpleParsedError = {
-  parser: IParser<unknown, unknown>;
+  parser: SomeParser;
   value: any;
   keys: string[];
 };
 export type ValidatorError = ISimpleParsedError;
 export type IParser<A, B> = {
-  readonly description: {
-    readonly name: ParserNames;
-    readonly extras: ReadonlyArray<unknown>;
-    readonly children: ReadonlyArray<IParser<unknown, unknown>>;
-  };
+  readonly description: Readonly<Description & {}>;
   parse<C, D>(this: IParser<A, B>, a: A, onParse: OnParse<A, B, C, D>): C | D;
 };
+export type Description = {
+  readonly name: ParserNames;
+  readonly extras: ReadonlyArray<unknown>;
+  readonly children: ReadonlyArray<SomeParser>;
+} & (
+  | {
+      readonly name: "Array";
+      readonly children: readonly [SomeParser];
+      readonly extras: readonly [];
+    }
+  | {
+      readonly name: "Concat";
+      readonly children: readonly [SomeParser, SomeParser];
+      readonly extras: readonly [];
+    }
+  | {
+      readonly name: "Default";
+      readonly children: readonly [SomeParser];
+      readonly extras: readonly [unknown];
+    }
+  | {
+      readonly name: "Dictionary";
+      readonly children: ReadonlyArray<SomeParser>;
+      readonly extras: readonly [];
+    }
+  | {
+      readonly name: "Guard";
+      readonly children: readonly [];
+      readonly extras: readonly [unknown];
+    }
+  | {
+      readonly name: "Literal";
+      readonly children: readonly [];
+      readonly extras: ReadonlyArray<unknown>;
+    }
+  | {
+      readonly name: "Mapped";
+      readonly children: readonly [SomeParser];
+      readonly extras: readonly [string];
+    }
+  | {
+      readonly name: "Maybe";
+      readonly children: readonly [SomeParser];
+      readonly extras: readonly [];
+    }
+  | {
+      readonly name: "Or";
+      readonly children: readonly [SomeParser, SomeParser];
+      readonly extras: readonly [];
+    }
+  | {
+      readonly name: "Wrapper";
+      readonly children: readonly [SomeParser];
+      readonly extras: readonly [];
+    }
+  | {
+      readonly name: "Shape";
+      readonly children: ReadonlyArray<SomeParser>;
+      readonly extras: ReadonlyArray<string | number>;
+    }
+);
 
 export type ParserNames =
   | "Array"
   | "Concat"
   | "Default"
   | "Dictionary"
-  | "Every"
   | "Guard"
   | "Literal"
   | "Mapped"

--- a/src/parsers/interfaces.ts
+++ b/src/parsers/interfaces.ts
@@ -76,7 +76,7 @@ export type Description = {
       readonly extras: readonly [];
     }
   | {
-      readonly name: "Shape";
+      readonly name: "Shape" | "Partial";
       readonly children: ReadonlyArray<SomeParser>;
       readonly extras: ReadonlyArray<string | number>;
     }
@@ -99,22 +99,23 @@ export type ParserNames =
   | "Any"
   | "Array"
   | "ArrayOf"
+  | "Boolean"
   | "Concat"
   | "Default"
   | "Dictionary"
+  | "Function"
   | "Guard"
   | "Literal"
   | "Mapped"
   | "Maybe"
   | "Named"
-  | "Number"
-  | "Boolean"
-  | "Function"
-  | "Object"
-  | "String"
   | "Null"
+  | "Number"
+  | "Partial"
+  | "Object"
   | "Or"
   | "Shape"
+  | "String"
   | "Wrapper";
 
 export type OnParse<A, B, C, D> = {


### PR DESCRIPTION
Making the description type to convert the parser into something else, like JsonSchema or typescript types. This brings in the names, children, and extras for each.

Moving several simple parsers into their own description and parsers. Useful for things like typescript that have primitives like strings, numbers, and booleans.
