### PR TITLE
fix: Allowing nulls

### DIFF
--- a/src/matches.test.ts
+++ b/src/matches.test.ts
@@ -261,6 +261,11 @@ test("should be able to test partial shape failure smaller", () => {
     }
     throw new Error("should be invalid");
   });
+  test("should be able to test shape with value `b` as null", () => {
+    const testValue = { b: null, a: "c" };
+
+    validator.unsafeCast(testValue);
+  });
   test("should be able to test shape with partial is wrong", () => {
     const testValue = { a: "c", b: "e" };
 
@@ -268,7 +273,7 @@ test("should be able to test partial shape failure smaller", () => {
       validator.unsafeCast(testValue);
     } catch (e) {
       assertSnapshot(
-        '"[\\"b\\"]Literal<\\"d\\">(\\"e\\")"',
+        '"[\\"b\\"]Maybe<Literal<\\"d\\">>(\\"e\\")"',
         validator.parse(testValue, unFold),
       );
       return;

--- a/src/parsers/shape-parser.ts
+++ b/src/parsers/shape-parser.ts
@@ -4,12 +4,12 @@ import { IParser, OnParse } from "./interfaces.ts";
 type _<T> = T;
 // prettier-ignore
 // deno-fmt-ignore
-export type MergeAll<T> = 
+export type MergeAll<T> =
   T extends ReadonlyArray<infer U> ? ReadonlyArray<MergeAll<U>> :
-  T extends object ? 
-    T extends null | undefined | never ? T :
-        _<{ [k in keyof T]: MergeAll<T[k]> }> 
-    : T;
+  T extends object ?
+  T extends null | undefined | never ? T :
+  _<{ [k in keyof T]: MergeAll<T[k]> }>
+  : T;
 /**
  * Given an object, we want to make sure the key exists and that the value on
  * the key matches the parser
@@ -160,7 +160,7 @@ export function shape<
         Object.fromEntries(
           entries
             .filter(([key, _]) => optionalSet.has(key as any))
-            .map(([key, parser]) => [key, parser]),
+            .map(([key, parser]) => [key, parser.optional()]),
         ),
       ),
       isShape(


### PR DESCRIPTION

### About

So the type that was assumed included the null as a possible input, but we didn't see it actually work
![image](https://user-images.githubusercontent.com/2364004/176273925-1b19f8cc-5973-488b-a356-8a2d8a0dbdde.png)
Fixes https://github.com/Blu-J/ts-matches/issues/505